### PR TITLE
Pretty printing fix and tests

### DIFF
--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/GraphQuery.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/GraphQuery.java
@@ -3,6 +3,8 @@
  */
 package oracle.pgql.lang.ir;
 
+import java.util.Objects;
+
 import static oracle.pgql.lang.ir.PgqlUtils.printPgqlString;
 
 public class GraphQuery {
@@ -79,10 +81,10 @@ public class GraphQuery {
 
     GraphQuery that = (GraphQuery) o;
 
-    if (limit != that.limit) {
+    if (!Objects.equals(limit, that.limit)) {
       return false;
     }
-    if (offset != that.offset) {
+    if (!Objects.equals(offset, that.offset)) {
       return false;
     }
     if (!projection.equals(that.projection)) {

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/PgqlUtils.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/PgqlUtils.java
@@ -228,7 +228,8 @@ public class PgqlUtils {
           }
           break;
         case PATH:
-          String pathAsString = deanonymizeIfNeeded(path, path.getConstraints());
+          QueryPath nestedPath = (QueryPath) connection;
+          String pathAsString = deanonymizeIfNeeded(nestedPath, path.getConstraints());
           if (connection.getSrc() == vertex) {
             result += pathAsString;
           } else {

--- a/pgql-lang/src/test/java/oracle/pgql/lang/PrettyPrintingTests.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/PrettyPrintingTests.java
@@ -28,8 +28,20 @@ public class PrettyPrintingTests {
   }
 
   @Test
+  public void testBasicGraphPattern1Reverse() throws Exception {
+    String query = "SELECT n.name WHERE (n) <- (m), m.prop1 = 'abc' AND n.prop2 = m.prop2";
+    checkRoundTrip(query);
+  }
+
+  @Test
   public void testBasicGraphPattern2() throws Exception {
     String query = "SELECT n.name WHERE (n) -[e]-> (), e.weight = 10 OR e.weight < n.weight";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testBasicGraphPattern2Reverse() throws Exception {
+    String query = "SELECT n.name WHERE (n) <-[e]- (), e.weight = 10 OR e.weight < n.weight";
     checkRoundTrip(query);
   }
 
@@ -46,6 +58,12 @@ public class PrettyPrintingTests {
   }
 
   @Test
+  public void testPathQuery1Reverse() throws Exception {
+    String query = "SELECT n.name, m.name WHERE (n) <-/:likes*/- (m)";
+    checkRoundTrip(query);
+  }
+
+  @Test
   public void testPathQuery2() throws Exception {
     String query = "PATH knows := (n:Person) -[e:likes|dislikes]-> (m:Person) SELECT n.name, m.name WHERE (n) -/:knows*/-> (m)";
     checkRoundTrip(query);
@@ -57,10 +75,40 @@ public class PrettyPrintingTests {
     checkRoundTrip(query);
   }
 
-  @Ignore("FIXME")
+  @Test
   public void testNestedPath() throws Exception {
     String query = "PATH abc := () -[:a|b|c]-> (b) PATH abc_star := () -/:abc*/-> () "
         + "PATH abc_star_star := () -/:abc_star*/-> () SELECT m.name WHERE (n) -/:abc_star_star+/-> (m)";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testQueryWithOrderBy() throws Exception {
+    String query = "SELECT m.name, m.age WHERE (m)->(n) ORDER BY m.age";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testQueryWithOrderByLimit() throws Exception {
+    String query = "SELECT m.name, m.age WHERE (m)->(n) ORDER BY m.age LIMIT 10";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testQueryWithOrderByOffsetLimit() throws Exception {
+    String query = "SELECT m.name, m.age WHERE (m)->(n) ORDER BY m.age OFFSET 2 LIMIT 1";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testQueryWithFromClause() throws Exception {
+    String query = "SELECT m.name, n.age FROM persons WHERE (m)->(n)";
+    checkRoundTrip(query);
+  }
+
+  @Test
+  public void testUndirectedEdge() throws Exception {
+    String query = "SELECT m.name, m.age WHERE (m)-(n)";
     checkRoundTrip(query);
   }
 


### PR DESCRIPTION
# Pretty printing of a QueryPath
When pretty printing a path pattern, the path name is repeated instead of the showing the right connection.

### Query: 
<pre>
PATH abc := () -[:a|b|c]-> (b) 
PATH abc_star := <b>() -/:abc*/-> ()</b>
PATH abc_star_star := <b>() -/:abc_star*/-> ()</b>
SELECT m.name 
WHERE (n) -/:abc_star_star+/-> (m)
</pre>

### Pretty printing of the query, before this pr:
<pre>
PATH abc := () -[anonymous_2]-> (b) WHERE (((anonymous_2.label() = 'a') OR (anonymous_2.label() = 'b')) OR (anonymous_2.label() = 'c'))
PATH abc_star_star := <b>() -/:abc_star_star+/-> ()</b>
PATH abc_star := <b>() -/:abc_star*/-> ()</b>
SELECT m.name
WHERE
  (n) -/:abc_star_star+/-> (m)
</pre>

### Pretty printing of the query, after this pr:
<pre>
PATH abc := () -[anonymous_2]-> (b) WHERE (((anonymous_2.label() = 'a') OR (anonymous_2.label() = 'b')) OR (anonymous_2.label() = 'c'))
PATH abc_star_star := <b>() -/:abc_star*/-> ()</b>
PATH abc_star := <b>() -/:abc*/-> ()</b>
SELECT m.name
WHERE
  (n) -/:abc_star_star+/-> (m)
</pre>

