### PR TITLE
don't allow SELECT n.* to end up returning zero columns

### DIFF
--- a/pgql-lang/src/test/java/oracle/pgql/lang/MetadataTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/MetadataTest.java
@@ -941,4 +941,28 @@ public class MetadataTest extends AbstractPgqlTest {
     PgqlResult result = parse("SELECT x.* FROM MATCH (v)");
     assertTrue(result.getErrorMessages().contains("Unresolved variable"));
   }
+
+  @Test
+  public void testSelectAllPropertiesZeroColumnsNotAllowed() throws Exception {
+    String error = "SELECT clause should have at least one column but has zero columns";
+
+    PgqlResult result = parse("SELECT e.* FROM MATCH () -[e:worksFor]-> () ON financialNetwork");
+    assertTrue(result.getErrorMessages().contains(error));
+
+    result = parse("SELECT e1.*, e2.* FROM MATCH () -[e1:worksFor]-> () -[e2:owner]-> () ON financialNetwork");
+    assertTrue(result.getErrorMessages().contains(error));
+
+    result = parse("SELECT DISTINCT e.*, e.* FROM MATCH () -[e:worksFor]-> () ON financialNetwork");
+    assertTrue(result.getErrorMessages().contains(error));
+
+    result = parse("SELECT 123, e.* FROM MATCH () -[e:worksFor]-> () ON financialNetwork");
+    assertTrue(result.isQueryValid());
+
+    result = parse("SELECT DISTINCT e.*, e.*, 123 FROM MATCH () -[e:worksFor]-> () ON financialNetwork");
+    assertTrue(result.isQueryValid());
+
+    result = parse("SELECT e.* FROM MATCH () -[e:worksFor|transaction]-> () ON financialNetwork");
+    assertTrue(result.isQueryValid());
+  }
+
 }

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -689,6 +689,12 @@ rules // MODIFY
     Edge(_, Identifier(e, _), _, _, _, Correlation(ExpressionPlusType(VarRef(Identifier(outer-var, _), _), type))) -> <fail>
     with <generate-error(|ctx, "Duplicate variable (variable with same name is passed from an outer query)")> e
 
+  // check SELECT clause is not empty (may happen in case of SELECT n.*)
+  nabl-constraint(|ctx):
+    SelectClause(distinctOrStar, e@ExpAsVars([])) -> <fail>
+    where <not(?Star())> distinctOrStar // for SELECT * (instead of SELECT n.*) with zero columns we already have a different error
+    with <generate-error(|ctx, "SELECT clause should have at least one column but has zero columns")> e
+
   // SUBSTRING
   nabl-constraint(|ctx, metadata):
     CharacterSubstring(ExpressionPlusType(exp, type@Type(t)), _, _) -> <fail>


### PR DESCRIPTION
(if graph metadata is available)