### PR TITLE
CREATE PROPERTY GRAPH and ONE ROW PER improvements

### DIFF
--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ddl/propertygraph/EdgeTable.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ddl/propertygraph/EdgeTable.java
@@ -132,23 +132,23 @@ public class EdgeTable extends ElementTable {
   }
 
   private String printSource() {
-    return "\n      SOURCE " + printVertexTableReference(edgeSourceKey, sourceVertexTable)
-        + printKeyForReferencedVertexTable(sourceVertexKey);
+    return "\n      SOURCE " + printVertexTableReference(edgeSourceKey, sourceVertexTable, sourceVertexKey);
   }
 
   private String printDestination() {
-    return "\n      DESTINATION " + printVertexTableReference(edgeDestinationKey, destinationVertexTable)
-        + printKeyForReferencedVertexTable(destinationVertexKey);
+    return "\n      DESTINATION "
+        + printVertexTableReference(edgeDestinationKey, destinationVertexTable, destinationVertexKey);
   }
 
-  private String printVertexTableReference(Key key, VertexTable referencedVertexTable) {
+  private String printVertexTableReference(Key key, VertexTable referencedVertexTable, Key refercedTableKey) {
     String vertexTableName = referencedVertexTable.getTableAlias() == null
         ? referencedVertexTable.getTableName().getName()
         : referencedVertexTable.getTableAlias();
     if (key == null) {
       return printIdentifier(vertexTableName, false);
     } else {
-      return "KEY " + key + " REFERENCES " + printIdentifier(vertexTableName, false);
+      return "KEY " + key + " REFERENCES " + printIdentifier(vertexTableName, false)
+          + printKeyForReferencedVertexTable(refercedTableKey);
     }
   }
 

--- a/pgql-lang/src/main/java/oracle/pgql/lang/Pgql.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/Pgql.java
@@ -289,7 +289,7 @@ public class Pgql implements Closeable {
           return new PgqlResult(queryString, queryValid, prettyMessages, statement, parseResult, LATEST_VERSION, 0,
               false, metadataProvider);
         } else {
-          System.out.println(e);
+          e.printStackTrace();
           LOG.debug("Translation of PGQL failed because of semantically invalid AST");
         }
       }

--- a/pgql-lang/src/main/java/oracle/pgql/lang/TranslateCreatePropertyGraph.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/TranslateCreatePropertyGraph.java
@@ -65,11 +65,13 @@ public class TranslateCreatePropertyGraph {
 
   private static int SOURCE_VERTEX_KEY = 0;
 
-  private static int SOURCE_VERTEX_TABLE_NAME = 1;
-
   private static int DESTINATION_VERTEX_KEY = 0;
 
-  private static int DESTINATION_VERTEX_TABLE_NAME = 1;
+  private static int REFERENCED_VERTEX_TABLE = 1;
+
+  private static int REFERENCED_VERTEX_TABLE_NAME = 0;
+
+  private static int REFERENCED_VERTEX_TABLE_COLUMN_LIST = 1;
 
   private static int LABEL_AND_PROPERTIES_CLAUSE_LABEL_AND_PROPERTIES_LIST = 0;
 
@@ -134,17 +136,21 @@ public class TranslateCreatePropertyGraph {
 
       IStrategoTerm sourceVertexTableT = edgeTableT.getSubterm(EDGE_TABLE_SOURCE_VERTEX_TABLE);
       Key edgeSourceKey = getKey(sourceVertexTableT.getSubterm(SOURCE_VERTEX_KEY));
-      IStrategoTerm sourceVertexTableNameT = sourceVertexTableT.getSubterm(SOURCE_VERTEX_TABLE_NAME);
+      IStrategoTerm referencedSourceVertexTable = sourceVertexTableT.getSubterm(REFERENCED_VERTEX_TABLE);
+      IStrategoTerm sourceVertexTableNameT = referencedSourceVertexTable.getSubterm(REFERENCED_VERTEX_TABLE_NAME);
       String sourceVertexTableName = getSchemaQualifiedName(sourceVertexTableNameT).getName();
       VertexTable sourceVertexTable = getVertexTable(vertexTables, sourceVertexTableName);
-      Key sourceVertexKey = null; // not supported for now
+      Key sourceVertexKey = getKey(referencedSourceVertexTable.getSubterm(REFERENCED_VERTEX_TABLE_COLUMN_LIST));
 
       IStrategoTerm destinationVertexTableT = edgeTableT.getSubterm(EDGE_TABLE_DESTINATION_VERTEX_TABLE);
       Key edgeDestinationKey = getKey(destinationVertexTableT.getSubterm(DESTINATION_VERTEX_KEY));
-      IStrategoTerm destinationVertexTableNameT = destinationVertexTableT.getSubterm(DESTINATION_VERTEX_TABLE_NAME);
+      IStrategoTerm referencedDestinationVertexTable = destinationVertexTableT.getSubterm(REFERENCED_VERTEX_TABLE);
+      IStrategoTerm destinationVertexTableNameT = referencedDestinationVertexTable
+          .getSubterm(REFERENCED_VERTEX_TABLE_NAME);
       String destinationVertexTableName = getSchemaQualifiedName(destinationVertexTableNameT).getName();
       VertexTable destinationVertexTable = getVertexTable(vertexTables, destinationVertexTableName);
-      Key destinationVertexKey = null; // not supported for now
+      Key destinationVertexKey = getKey(
+          referencedDestinationVertexTable.getSubterm(REFERENCED_VERTEX_TABLE_COLUMN_LIST));
 
       List<Label> labels = getLabels(edgeTableT.getSubterm(EDGE_TABLE_LABEL_AND_PROPERTIES));
       result.add(new EdgeTable(tableName, tableAlias, edgeKey, sourceVertexTable, edgeSourceKey, sourceVertexKey,

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -232,7 +232,7 @@ public class BugFixTest extends AbstractPgqlTest {
         "  vertex tables (\n" + //
         "    Person, Person\n" + //
         "  )";
-    String errorMessage = "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)";
+    String errorMessage = "Duplicate table name; use an alias to make the table names unique (table AS alias)";
     assertTrue(pgql.parse(statement).getErrorMessages().contains(errorMessage));
   }
 
@@ -246,7 +246,7 @@ public class BugFixTest extends AbstractPgqlTest {
         "    knows SOURCE Person DESTINATION Person,\n" + //
         "    knows SOURCE Person DESTINATION Person\n" + //
         "  )";
-    String errorMessage = "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)";
+    String errorMessage = "Duplicate table name; use an alias to make the table names unique (table AS alias)";
     assertTrue(pgql.parse(statement).getErrorMessages().contains(errorMessage));
   }
 

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -232,7 +232,7 @@ public class BugFixTest extends AbstractPgqlTest {
         "  vertex tables (\n" + //
         "    Person, Person\n" + //
         "  )";
-    String errorMessage = "Duplicate table name; use an alias to make the table names unique (table AS alias)";
+    String errorMessage = "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)";
     assertTrue(pgql.parse(statement).getErrorMessages().contains(errorMessage));
   }
 
@@ -246,7 +246,7 @@ public class BugFixTest extends AbstractPgqlTest {
         "    knows SOURCE Person DESTINATION Person,\n" + //
         "    knows SOURCE Person DESTINATION Person\n" + //
         "  )";
-    String errorMessage = "Duplicate table name; use an alias to make the table names unique (table AS alias)";
+    String errorMessage = "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)";
     assertTrue(pgql.parse(statement).getErrorMessages().contains(errorMessage));
   }
 

--- a/pgql-lang/src/test/java/oracle/pgql/lang/PrettyPrintingTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/PrettyPrintingTest.java
@@ -505,6 +505,18 @@ public class PrettyPrintingTest extends AbstractPgqlTest {
   }
 
   @Test
+  public void testReferencedVertexTableKeyInCreatePropertyGraph() throws Exception {
+    String statement = "CREATE PROPERTY GRAPH hr " + //
+        "  VERTEX TABLES ( employees ) " + //
+        "  EDGE TABLES ( " + //
+        "    employees AS works_for " + //
+        "      SOURCE KEY ( employee_id ) REFERENCES employees ( employee_id ) " + //
+        "      DESTINATION KEY ( manager_id ) REFERENCES employees ( employee_id ) " + //
+        "  )";
+    checkRoundTrip(statement);
+  }
+
+  @Test
   public void testCreatePropertyGraphPgView() throws Exception {
     String statement = "CREATE PROPERTY GRAPH STUDENT_NETWORK\n" + //
         "  VERTEX TABLES (\n" + //

--- a/pgql-spoofax/syntax/DDL.sdf3
+++ b/pgql-spoofax/syntax/DDL.sdf3
@@ -30,11 +30,13 @@ context-free syntax // CREATE PROPERTY GRAPH
 
   TableAlias.TableAlias = Identifier
 
-  SourceVertexTable.SourceVertexTable = <SOURCE <ReferencedVertexTableKeyClause?> <TableName>> {case-insensitive}
+  SourceVertexTable.SourceVertexTable = <SOURCE <ReferencingKeyClause?> <ReferencedVertexTable>> {case-insensitive}
 
-  DestinationVertexTable.DestinationVertexTable = <DESTINATION <ReferencedVertexTableKeyClause?> <TableName>> {case-insensitive}
+  DestinationVertexTable.DestinationVertexTable = <DESTINATION <ReferencingKeyClause?> <ReferencedVertexTable>> {case-insensitive}
 
-  ReferencedVertexTableKeyClause.ReferencedVertexTableKeyClause = <<KeyClause> REFERENCES> {case-insensitive}
+  ReferencingKeyClause.ReferencingKeyClause = <<KeyClause> REFERENCES> {case-insensitive}
+
+  ReferencedVertexTable.ReferencedVertexTable = <<TableName> <ReferencedColumnList?>>
 
   LabelAndPropertiesClause.LabelAndPropertiesClause = LabelAndProperties+
 
@@ -55,6 +57,8 @@ context-free syntax // CREATE PROPERTY GRAPH
   ExceptColumns.Except = <EXCEPT ( <{Identifier ","}+> )> {case-insensitive}
 
   KeyClause.KeyClause = <KEY ( <{Identifier ","}+> )> {case-insensitive}
+
+  ReferencedColumnList.ReferencedColumnList = <( <{Identifier ","}+> )>
 
 context-free syntax // DROP PROPERTY GRAPH
 

--- a/pgql-spoofax/syntax/pgql-lang.sdf3
+++ b/pgql-spoofax/syntax/pgql-lang.sdf3
@@ -45,11 +45,14 @@ context-free syntax
 
   TableExpression = GraphMatch
 
-  GraphMatch.GraphMatch = <<MatchKeyword?> <PathPattern> <RowsPerMatch?> <OnClause?>>
+  GraphMatch.GraphMatch = MatchKeyword? PathPattern OptionalGraphMatchParts?
 
-  GraphMatch.ParenthesizedGraphMatch = <MATCH ( <{PathPattern ","}+> ) <RowsPerMatch?> <OnClause?>> {case-insensitive}
+  GraphMatch.ParenthesizedGraphMatch = <MATCH ( <{PathPattern ","}+> ) <OptionalGraphMatchParts?>> {case-insensitive}
 
   MatchKeyword.MatchKeyword = <MATCH> {case-insensitive}
+
+  OptionalGraphMatchParts.OptionalGraphMatchParts1 = RowsPerMatch OnClause? // deprecated
+  OptionalGraphMatchParts.OptionalGraphMatchParts2 = OnClause RowsPerMatch?
 
   OnClause.OnClause = <ON <GraphName>> {case-insensitive}
 

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -494,9 +494,9 @@ rules // MODIFY
   nabl-constraint(|ctx):
     CreatePropertyGraph(_, VertexTables(vertexTables), EdgeTables(edgeTables), _) -> <fail>
     with vertexTableNames := <map(?VertexTable(_, <id>, _, _); to-identifier-without-origin-info)> vertexTables
+       ; <generate-error-on-duplicates(|ctx, "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)")> vertexTableNames
        ; edgeTableNames := <map(?EdgeTable(_, <id>, _, _, _, _); to-identifier-without-origin-info)> edgeTables
-       ; allTableNames := <conc> (vertexTableNames, edgeTableNames)
-       ; <generate-error-on-duplicates(|ctx, "Duplicate table name; use an alias to make the table names unique (table AS alias)")> allTableNames
+       ; <generate-error-on-duplicates(|ctx, "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)")> edgeTableNames
        ; vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
                                              ?DestinationVertexTable(_, ReferencedVertexTable(Name(_, <id>), _))
                                            ); to-identifier-without-origin-info)> edgeTables

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -497,7 +497,9 @@ rules // MODIFY
        ; <generate-error-on-duplicates(|ctx, "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)")> vertexTableNames
        ; edgeTableNames := <map(?EdgeTable(_, <id>, _, _, _, _); to-identifier-without-origin-info)> edgeTables
        ; <generate-error-on-duplicates(|ctx, "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)")> edgeTableNames
-       ; vertexTableReferences := <collect((?SourceVertexTable(_, Name(_, <id>)) + ?DestinationVertexTable(_, Name(_, <id>))); to-identifier-without-origin-info)> edgeTables
+       ; vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
+                                             ?DestinationVertexTable(_, ReferencedVertexTable(Name(_, <id>), _))
+                                           ); to-identifier-without-origin-info)> edgeTables
        ; unresolvedVertexTableReferences := <diff> (vertexTableReferences, vertexTableNames)
        ; <batch-generate-error(|ctx, "Undefined vertex table")> unresolvedVertexTableReferences
 
@@ -511,9 +513,13 @@ rules // MODIFY
        ; <batch-generate-error(|ctx, "Alias required (.. AS name)")> complexExpressionsWithoutAlias
 
   nabl-constraint(|ctx):
-    t -> <fail>
-    where <?SourceVertexTable(_, Name(Some(schemaName), _)) + ?DestinationVertexTable(_, Name(Some(schemaName), _))> t
+    ReferencedVertexTable(Name(Some(schemaName), _), _) -> <fail>
     with <generate-error(|ctx, "Schema name not allowed here")> schemaName
+
+  nabl-constraint(|ctx):
+    t -> <fail>
+    where <?SourceVertexTable(None(), ReferencedVertexTable(_, Some(_))) + ?DestinationVertexTable(None(), ReferencedVertexTable(_, Some(_)))> t
+    with <generate-error(|ctx, "Referenced column list provided but no KEY clause specified")> t
 
 // LISTAGG
 

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -511,6 +511,8 @@ rules // MODIFY
        ; <batch-generate-error(|ctx, "Only column references and simple CAST expressions allowed; arbitrary expressions are not yet supported")> expAsVarsWithComplexExpressions
        ; complexExpressionsWithoutAlias := <remove-all(?ExpAsVar(VarRef(_), _) + ?ExpAsVar(_, Identifier(_, _)))> expAsVars
        ; <batch-generate-error(|ctx, "Alias required (.. AS name)")> complexExpressionsWithoutAlias
+       ; propertyNames := <filter(?ExpAsVar(_, Identifier(<id>, _)))> expAsVars
+       ; <generate-error-on-duplicates(|ctx, "Duplicate property name")> propertyNames
 
   nabl-constraint(|ctx):
     ReferencedVertexTable(Name(Some(schemaName), _), _) -> <fail>

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -494,9 +494,9 @@ rules // MODIFY
   nabl-constraint(|ctx):
     CreatePropertyGraph(_, VertexTables(vertexTables), EdgeTables(edgeTables), _) -> <fail>
     with vertexTableNames := <map(?VertexTable(_, <id>, _, _); to-identifier-without-origin-info)> vertexTables
-       ; <generate-error-on-duplicates(|ctx, "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)")> vertexTableNames
        ; edgeTableNames := <map(?EdgeTable(_, <id>, _, _, _, _); to-identifier-without-origin-info)> edgeTables
-       ; <generate-error-on-duplicates(|ctx, "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)")> edgeTableNames
+       ; allTableNames := <conc> (vertexTableNames, edgeTableNames)
+       ; <generate-error-on-duplicates(|ctx, "Duplicate table name; use an alias to make the table names unique (table AS alias)")> allTableNames
        ; vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
                                              ?DestinationVertexTable(_, ReferencedVertexTable(Name(_, <id>), _))
                                            ); to-identifier-without-origin-info)> edgeTables

--- a/pgql-spoofax/trans/normalize-ddl.str
+++ b/pgql-spoofax/trans/normalize-ddl.str
@@ -36,8 +36,8 @@ rules // CREATE PROPERTY GRAPH
     EdgeTable(name@Name(_, tableName), tableAlias, keyClause, sourceVertexTable, destinationVertexTable, labelAndPropertiesClause)
       -> EdgeTable(name, tableAlias', keyClause, sourceVertexTable', destinationVertexTable', labelAndPropertiesClause')
     with tableAlias' := <normalize-tableAlias(|tableName)> tableAlias
-       ; sourceVertexTable' := <SourceVertexTable(normalize-ReferencedVertexTableKeyClause, id)> sourceVertexTable
-       ; destinationVertexTable' := <DestinationVertexTable(normalize-ReferencedVertexTableKeyClause, id)> destinationVertexTable
+       ; sourceVertexTable' := <origin-track-forced(SourceVertexTable(normalize-ReferencingKeyClause, id))> sourceVertexTable
+       ; destinationVertexTable' := <origin-track-forced(DestinationVertexTable(normalize-ReferencingKeyClause, id))> destinationVertexTable
        ; labelAndPropertiesClause' := <normalize-LabelAndPropertiesClause(|tableAlias')> labelAndPropertiesClause
 
   normalize-tableAlias(|tableName):
@@ -91,10 +91,10 @@ rules // CREATE PROPERTY GRAPH
     ExpAsVar(exp@VarRef(columnName), None()) -> ExpAsVar(exp, propertyName)
     with propertyName := columnName
 
-  normalize-ReferencedVertexTableKeyClause:
-    Some(ReferencedVertexTableKeyClause(keyClause)) -> Some(keyClause)
+  normalize-ReferencingKeyClause:
+    Some(ReferencingKeyClause(keyClause)) -> Some(keyClause)
 
-  normalize-ReferencedVertexTableKeyClause:
+  normalize-ReferencingKeyClause:
     None() -> None()
 
 rules // DROP PROPERTY GRAPH

--- a/pgql-spoofax/trans/normalize.str
+++ b/pgql-spoofax/trans/normalize.str
@@ -122,17 +122,19 @@ rules
 
   get-pgql13-deprecation = get-pgql11-deprecation // sharing all the deprecations with 1.1
 
-  get-pgql13-errors      = ?GraphMatch(None(), _, _, _); to-error-message(|"Missing MATCH keyword at start of pattern")
+  get-pgql13-errors      = ?GraphMatch(None(), _, _); to-error-message(|"Missing MATCH keyword at start of pattern")
 
   get-pgql13-errors:
-    ParenthesizedGraphMatch(pathPatterns, rowsPerMatch, _) -> <to-error-message(|"ONE ROW PER VERTEX, EDGE or STEP is only permitted if the MATCH clause contains a single path pattern")> rowsPerMatch
+    ParenthesizedGraphMatch(pathPatterns, optionalGraphMatchParts) -> <to-error-message(|"ONE ROW PER VERTEX or STEP is only permitted if the MATCH clause contains a single path pattern")> rowsPerMatch
     where <gt> (<length> pathPatterns, 1)
+        ; rowsPerMatch := <get-RowsPerMatch> optionalGraphMatchParts
         ; <?Some(OneRowPerVertex(_)) + ?Some(OneRowPerEdge(_)) + ?Some(OneRowPerStep(_, _, _))> rowsPerMatch
 
   get-pgql13-errors:
-    x -> <to-error-message(|"ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST")> rowsPerMatch
-    where <?ParenthesizedGraphMatch([PathPattern(_, _)], rowsPerMatch, _) + ?GraphMatch(_, PathPattern(_, _), rowsPerMatch, _) +
-           ?ParenthesizedGraphMatch([SingleVertex(_)], rowsPerMatch, _) + ?GraphMatch(_, SingleVertex(_), rowsPerMatch, _)> x
+    x -> <to-error-message(|"ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST")> rowsPerMatch
+    where <?ParenthesizedGraphMatch([PathPattern(_, _)], optionalGraphMatchParts) + ?GraphMatch(_, PathPattern(_, _), optionalGraphMatchParts) +
+           ?ParenthesizedGraphMatch([SingleVertex(_)], optionalGraphMatchParts) + ?GraphMatch(_, SingleVertex(_), optionalGraphMatchParts)> x
+        ; rowsPerMatch := <get-RowsPerMatch> optionalGraphMatchParts
         ; <?Some(OneRowPerVertex(_)) + ?Some(OneRowPerEdge(_)) + ?Some(OneRowPerStep(_, _, _))> rowsPerMatch
 
   get-pgql10-limitation = ( ?Pgql11FromClause(_)
@@ -177,12 +179,22 @@ rules
          else errors := []
          end
 
-  get-on-clause-graph-name = ?GraphMatch(_, _, _, Some(OnClause(<id>))) + ?ParenthesizedGraphMatch(_, _, Some(OnClause(<id>)))
+  get-on-clause-graph-name = ?GraphMatch(_, _, Some(OptionalGraphMatchParts1(_, Some(OnClause(<id>)))))
+                           + ?ParenthesizedGraphMatch(_, Some(OptionalGraphMatchParts1(_, Some(OnClause(<id>)))))
+                           + ?GraphMatch(_, _, Some(OptionalGraphMatchParts2(OnClause(<id>), _)))
+                           + ?ParenthesizedGraphMatch(_, Some(OptionalGraphMatchParts2(OnClause(<id>), _)))
+
+  get-RowsPerMatch = ?None()
+                   + origin-track-forced(?Some(OptionalGraphMatchParts1(<id>, _)); (?None() <+ !Some(<id>)))
+                   + origin-track-forced(?Some(OptionalGraphMatchParts2(_, <id>)))
 
   get-errors-for-missing-on-clauses:
     ast -> errors
     with if <oncetd(?OnClause(_))> ast
-         then clausesWithMissingGraphName := <collect(?GraphMatch(_, _, _, None()) + ?ParenthesizedGraphMatch(_, _, None()))> ast
+         then clausesWithMissingGraphName := <collect(?GraphMatch(_, _, Some(OptionalGraphMatchParts1(_, None())))
+						                            + ?ParenthesizedGraphMatch(_, Some(OptionalGraphMatchParts1(_, None())))
+						                            + ?GraphMatch(_, _, None())
+						                            + ?ParenthesizedGraphMatch(_, None()))> ast
             ; errors := <map(to-error-message(|"Missing ON clause"))> clausesWithMissingGraphName
          else errors := []
          end
@@ -355,12 +367,12 @@ rules
   // PGQL 1.3
   norm-matchElems(|variable-counter):
     FromWhereClauses(graphMatches, whereClause) -> GraphPatternAndGraphName(graphPattern, graphName, whereClause)
-    with graphName := <map(?GraphMatch(_, _, _, <id>) + ?ParenthesizedGraphMatch(_, _, <id>)); (Hd; normalize-OnClause <+ !None())> graphMatches // simply take the first graph name we see; we don't support multiple graph right now
+    with graphName := <filter(get-on-clause-graph-name); (Hd; !Some(GraphName(<id>)) <+ !None())> graphMatches // simply take the first graph name we see; we don't support multiple graph right now
        ; pathPatternsWithRowsPerMatch := <map(get-pathPatternsAndRowsPerMatch); concat> graphMatches
        ; graphPattern := <norm-matchElems-common(|variable-counter)> pathPatternsWithRowsPerMatch
 
-  get-pathPatternsAndRowsPerMatch = ?GraphMatch(_, pathPattern, rowsPerMatch, _); ![PathPatternAndRowsPerMatch(pathPattern, rowsPerMatch)]
-                                  + ?ParenthesizedGraphMatch(<id>, rowsPerMatch, _); map(!PathPatternAndRowsPerMatch(<id>, rowsPerMatch))
+  get-pathPatternsAndRowsPerMatch = ?GraphMatch(_, pathPattern, optionalGraphMatchParts); ![PathPatternAndRowsPerMatch(pathPattern, <get-RowsPerMatch> optionalGraphMatchParts)]
+                                  + ?ParenthesizedGraphMatch(<id>, optionalGraphMatchParts); map(!PathPatternAndRowsPerMatch(<id>, <get-RowsPerMatch> optionalGraphMatchParts))
 
   // PGQL 1.1 and 1.2
   norm-matchElems(|variable-counter):
@@ -388,8 +400,6 @@ rules
                                                                        + ?UndirectedEdge(<id>, None()))
                                         ; filter(get-inlined-constraints); concat> pathPatterns
        ; constraints := <conc; flatten-list; !Constraints(<id>)> (inlined-constraints-for-vertices, inlined-constraints-for-edges, non-inlined-constraints)
-
-  normalize-OnClause = ?Some(OnClause(<id>)); !Some(GraphName(<id>))
 
   collect-outside-repeated-path(s) = collect-but-preserve-order(ParenthesizedPath + s); remove-all(ParenthesizedPath)
 

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -27,7 +27,7 @@ test Undefined vertex table (2) [[
 
 ]] error like "Undefined vertex table" at #1 // should use "Employee" instead
 
-test Duplicate vertex and edge tables (1) [[
+test Duplicate vertex and edge tables [[
 
   CREATE PROPERTY GRAPH MyGraph
     VERTEX TABLES (
@@ -38,19 +38,8 @@ test Duplicate vertex and edge tables (1) [[
       [[knows]] SOURCE Person DESTINATION Person
     )
 
-]] error like "Duplicate table name; use an alias to make the table names unique (table AS alias)" at #1, #2, #3, #4
-
-test Duplicate vertex and edge tables (2) [[
-
-  CREATE PROPERTY GRAPH MyGraph
-    VERTEX TABLES (
-      [[Employees]]
-    )
-    EDGE TABLES (
-      [[Employees]] SOURCE Employees DESTINATION Employees
-    )
-
-]] error like "Duplicate table name; use an alias to make the table names unique (table AS alias)" at #1, #2
+]] error like "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)" at #1, #2
+   error like "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)" at #3, #4
 
 test Complex expressions as property not allowed [[
 

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -12,7 +12,8 @@ test Undefined vertex table (1) [[
       studentOf SOURCE [[Student.Person]] DESTINATION [[University]]
     )
 
-]] error like "Undefined vertex table" at #1, #2
+]] error like "Schema name not allowed here" at #1
+   error like "Undefined vertex table" at #2
 
 test Undefined vertex table (2) [[
 
@@ -69,3 +70,14 @@ test Missing property name [[
     )
 
 ]] error like "Alias required (.. AS name)" at #1, #2
+
+test Missing KEY clause [[
+
+  CREATE PROPERTY GRAPH hr
+    VERTEX TABLES ( employees )
+    EDGE TABLES (
+      employees AS works_for
+        [[source employees ( employee_id )]]
+        [[destination employees ( employee_id )]]
+    )
+]] error like "Referenced column list provided but no KEY clause specified" at #1, #2

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -82,6 +82,21 @@ test Missing property name [[
 
 ]] error like "Alias required (.. AS name)" at #1, #2
 
+test Duplicate property name [[
+
+  CREATE PROPERTY GRAPH myGraph
+    VERTEX TABLES (
+      Person PROPERTIES ( [[c1]], c2 AS [[c1]], [[c3]], [[c3]] )
+    )
+    EDGE TABLES (adsfad
+      knows
+        SOURCE Person
+        DESTINATION Person
+        PROPERTIES ( [[c1]], c2 AS [[c1]], [[c3]], [[c3]] )
+    )
+
+]] error like "Duplicate property name" at #1, #2, #3, #4, #5, #6, #7, #8
+
 test Missing KEY clause [[
 
   CREATE PROPERTY GRAPH hr

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -27,7 +27,7 @@ test Undefined vertex table (2) [[
 
 ]] error like "Undefined vertex table" at #1 // should use "Employee" instead
 
-test Duplicate vertex and edge tables [[
+test Duplicate vertex and edge tables (1) [[
 
   CREATE PROPERTY GRAPH MyGraph
     VERTEX TABLES (
@@ -38,8 +38,19 @@ test Duplicate vertex and edge tables [[
       [[knows]] SOURCE Person DESTINATION Person
     )
 
-]] error like "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)" at #1, #2
-   error like "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)" at #3, #4
+]] error like "Duplicate table name; use an alias to make the table names unique (table AS alias)" at #1, #2, #3, #4
+
+test Duplicate vertex and edge tables (2) [[
+
+  CREATE PROPERTY GRAPH MyGraph
+    VERTEX TABLES (
+      [[Employees]]
+    )
+    EDGE TABLES (
+      [[Employees]] SOURCE Employees DESTINATION Employees
+    )
+
+]] error like "Duplicate table name; use an alias to make the table names unique (table AS alias)" at #1, #2
 
 test Complex expressions as property not allowed [[
 

--- a/pgql-tests/error-messages/variable-length-paths.spt
+++ b/pgql-tests/error-messages/variable-length-paths.spt
@@ -308,63 +308,70 @@ test ONE ROW PER VERTEX no quantifier (1) [[
   SELECT 1
     FROM MATCH (n) [[ONE ROW PER VERTEX (v)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER VERTEX no quantifier (2) [[
 
   SELECT 1
     FROM MATCH (n) ->* (m) [[ONE ROW PER VERTEX (v)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER EDGE no quantifier (1) [[
 
   SELECT 1
     FROM MATCH (n) [[ONE ROW PER EDGE (e)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER EDGE no quantifier (2) [[
 
   SELECT 1
     FROM MATCH (n) ->* (m) [[ONE ROW PER EDGE (e)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER STEP no quantifier (1) [[
 
   SELECT 1
     FROM MATCH (n) [[ONE ROW PER STEP (v1, e, v2)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER STEP no quantifier (2) [[
 
   SELECT 1
     FROM MATCH (n) ->* (m) [[ONE ROW PER STEP (v1, e, v2)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only supported in combination with ANY, ALL, SHORTEST or CHEAPEST" at #1
 
 test ONE ROW PER VERTEX with multiple path patterns [[
 
   SELECT 1
     FROM MATCH ( ANY (a) -> (b), ANY (b) -> (c) ) [[ONE ROW PER VERTEX (v)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
 
 test ONE ROW PER EDGE with multiple path patterns [[
 
   SELECT 1
     FROM MATCH ( ANY (a) ->* (b), ANY (b) ->* (c) ) [[ONE ROW PER EDGE (e)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
 
-test ONE ROW PER EDGE with multiple path patterns [[
+test ONE ROW PER STEP with multiple path patterns [[
 
   SELECT 1
     FROM MATCH ( ANY (a) ->* (b), ANY (b) ->* (c) ) [[ONE ROW PER STEP (v1, e, v2)]]
 
-]] error like "ONE ROW PER VERTEX, EDGE or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
+]] error like "ONE ROW PER VERTEX or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
+
+test ONE ROW PER with multiple path patterns and ON clause [[
+
+  SELECT 1
+    FROM MATCH ( ANY (a) ->* (b), ANY (b) ->* (c) ) ON g [[ONE ROW PER STEP (v1, e, v2)]]
+
+]] error like "ONE ROW PER VERTEX or STEP is only permitted if the MATCH clause contains a single path pattern" at #1
 
 test ONE ROW PER VERTEX duplicate variable (1) [[
 

--- a/pgql-tests/syntax/grouping-and-aggregating.spt
+++ b/pgql-tests/syntax/grouping-and-aggregating.spt
@@ -10,7 +10,6 @@ test Aggregate over empty group [[
 
 ]]
 
-
 test Basic GROUP BY 1 [[
 
     SELECT n.age, COUNT(*), AVG(n.salary), LISTAGG(n.salary), MIN(n.salary), MAX(n.salary), SUM(n.salary)

--- a/pgql-tests/syntax/pattern-matching.spt
+++ b/pgql-tests/syntax/pattern-matching.spt
@@ -50,3 +50,19 @@ WHERE
   (n1) -> (n2),
   (n2) -> (n3)
 ]]
+
+test ON clause before rows per match (1) [[
+
+SELECT *
+FROM MATCH ANY (n) ->* (m) ON g
+       ONE ROW PER STEP ( v1, e, v2 )
+
+]]
+
+test ON clause before rows per match (2) [[
+
+SELECT *
+FROM MATCH ( ANY (n) ->* (m) ) ON g
+       ONE ROW PER STEP ( v1, e, v2 )
+
+]]


### PR DESCRIPTION
- add support for source&destination vertex keys
- duplicate properties in PROPERTIES now errors out
- fixes the order of the ON clause and ONE ROW PER clause (ON clause should've come first)