### PR TITLE
PREFIX not preserved when parsing without metadata

### DIFF
--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryExpression.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryExpression.java
@@ -2334,8 +2334,11 @@ public interface QueryExpression {
 
     private VarRef varRef;
 
-    public AllProperties(VarRef varRef) {
+    private String prefix;
+
+    public AllProperties(VarRef varRef, String prefix) {
       this.varRef = varRef;
+      this.prefix = prefix;
     }
 
     public VarRef getVarRef() {
@@ -2346,6 +2349,14 @@ public interface QueryExpression {
       this.varRef = varRef;
     }
 
+    public String getPrefix() {
+      return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+      this.prefix = prefix;
+    }
+
     @Override
     public ExpressionType getExpType() {
       return ExpressionType.ALL_PROPERTIES;
@@ -2353,7 +2364,7 @@ public interface QueryExpression {
 
     @Override
     public String toString() {
-      return varRef + ".*";
+      return varRef + ".*" + (prefix == null ? "" : " PREFIX " + prefix);
     }
 
     @Override
@@ -2375,6 +2386,11 @@ public interface QueryExpression {
       if (getClass() != obj.getClass())
         return false;
       AllProperties other = (AllProperties) obj;
+      if (prefix == null) {
+        if (other.prefix != null)
+          return false;
+      } else if (!prefix.equals(other.prefix))
+        return false;
       if (varRef == null) {
         if (other.varRef != null)
           return false;

--- a/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
@@ -185,6 +185,7 @@ public class SpoofaxAstToGraphQuery {
   private static final int POS_EXP_PLUS_TYPE_EXP = 0;
 
   private static final int POS_ALLPROPERTIES_VARREF = 0;
+  private static final int POS_ALLPROPERTIES_PREFIX = 1;
 
   private static final int POS_DERIVED_TABLE_LATERAL = 0;
   private static final int POS_DERIVED_TABLE_SUBQUERY = 1;
@@ -881,7 +882,9 @@ public class SpoofaxAstToGraphQuery {
         VarRef varRef = (VarRef) translateExp(expAsVarT.getSubterm(POS_ALLPROPERTIES_VARREF), ctx);
         String expAsVarName = GENERATED_VAR_SUBSTR + "_" + varRef + ".*"; // this just needs to be some unique name;
                                                                           // doesn't matter what
-        ExpAsVar expAsVar = new ExpAsVar(new AllProperties(varRef), expAsVarName, true, expAsVarName);
+        IStrategoTerm prefixT = expAsVarT.getSubterm(POS_ALLPROPERTIES_PREFIX);
+        String prefix = isSome(prefixT) ? getString(prefixT) : null;
+        ExpAsVar expAsVar = new ExpAsVar(new AllProperties(varRef, prefix), expAsVarName, true, expAsVarName);
         expAsVars.add(expAsVar);
         continue;
       }

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -9,20 +9,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import oracle.pgql.lang.ir.ExpAsVar;
 import oracle.pgql.lang.ir.GraphQuery;
+import oracle.pgql.lang.ir.QueryExpression.AllProperties;
 import oracle.pgql.lang.ir.QueryExpression.FunctionCall;
 import oracle.pgql.lang.ir.QueryExpression.PropertyAccess;
 import oracle.pgql.lang.ir.SelectQuery;
 
 public class BugFixTest extends AbstractPgqlTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   /* OL-Jira GM-13537 */
   @Test
@@ -332,5 +328,12 @@ public class BugFixTest extends AbstractPgqlTest {
 
     prettyPrintedQuery = pgql.parse("SELECT e.prop AS e1, e.prop AS e2 FROM MATCH (v)-[e]->(v1) GROUP BY e1, e2").getGraphQuery().toString();
     assertTrue(pgql.parse(prettyPrintedQuery).isQueryValid());
+  }
+
+  @Test
+  public void testPreservePrefixWhenNoMetadata() throws Exception {
+    SelectQuery query = (SelectQuery) pgql.parse("SELECT n.* PREFIX 'N_' FROM MATCH (n)").getGraphQuery();
+    AllProperties allProperties = (AllProperties) query.getProjection().getElements().get(0).getExp();
+    assertEquals("N_", allProperties.getPrefix());
   }
 }

--- a/pgql-lang/src/test/java/oracle/pgql/lang/SyntaxErrorsTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/SyntaxErrorsTest.java
@@ -3,7 +3,8 @@
  */
 package oracle.pgql.lang;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 


### PR DESCRIPTION
PREFIX (e.g. SELECT n.* PREFIX 'N_' ..) was not preserved in the query IR if the query was parsed without providing graph metadata.