### PR TITLE
remove unneeded third parties

### DIFF
--- a/pgql-lang/pom.xml
+++ b/pgql-lang/pom.xml
@@ -22,6 +22,22 @@
           <groupId>com.google.inject.extensions</groupId>
           <artifactId>guice-multibindings</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.oracle.truffle</groupId>
+          <artifactId>truffle-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.graalvm</groupId>
+          <artifactId>graal-sdk</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.reactivex.rxjava3</groupId>
+          <artifactId>rxjava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
New dependency tree looks like this:

```
[INFO] oracle.pg:pgql-lang:jar:0.0.0-SNAPSHOT
[INFO] +- oracle.pg:graph-query-ir:jar:0.0.0-SNAPSHOT:compile
[INFO] +- org.metaborg:org.metaborg.spoofax.core.uber:jar:2.5.16:compile
[INFO] |  +- io.usethesource:capsule:jar:0.6.3:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.7:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.8:compile
[INFO] |  +- com.virtlink.commons:commons-configuration2-jackson:jar:0.10.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.11.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.11.0:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.11.0:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.26:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  +- com.google.inject:guice:jar:4.2.0:compile
[INFO] |  +- javax.inject:javax.inject:jar:1:compile
[INFO] |  +- aopalliance:aopalliance:jar:1.0:compile
[INFO] |  +- commons-io:commons-io:jar:2.6:compile
[INFO] |  +- org.apache.commons:commons-vfs2:jar:2.6.0:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- com.google.guava:guava:jar:26.0-jre:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.8.1:compile
[INFO] \- junit:junit:jar:4.13.1:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
```