### PR TITLE
Optimization: push down more predicates into LATERAL

### DIFF
--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -82,7 +82,14 @@ rules
                         , <alltd(push-down-predicates(|variablesOuterQuery'''))> orderBy
                         , limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables)
     with expressions' := <map(conjunction-to-list); concat> expressions
-       ; expressions-plus-varRefs := <map(make-expressions-varRefs-tuple)> expressions'
+
+         // references to vertices that correlate with vertices in SELECT of prior LATERAL subquery are replaced with references to those prior vertices
+         // this allows for pushing down even more predicates
+       ; vertices-projected-by-laterals := <filter(?DerivedTable(Some(Lateral()), Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)); flatten-list; filter(?ExpAsVar(_, _, _, <id>))> tableExpressions
+       ; lateralVertexCorrelations := <collect(vertex-correlates-to-vertex-projected-by-lateral-subquery(|vertices-projected-by-laterals))> tableExpressions
+       ; expressions'' := <alltd(dereference-vertex-correlation(|lateralVertexCorrelations))> expressions'
+
+       ; expressions-plus-varRefs := <map(make-expressions-varRefs-tuple)> expressions''
        ; (non-pushed-down-predicates-plus-varRefs, tableExpressions', allNewVariables) := <foldl(try-push-down-predicates(|variablesOuterQuery))> (tableExpressions, (expressions-plus-varRefs, [], []))
        ; non-pushed-down-predicates := <map(?(<id>, _))> non-pushed-down-predicates-plus-varRefs
        ; variablesOuterQuery' := <conc; make-set> (variablesOuterQuery, allNewVariables)
@@ -112,10 +119,10 @@ rules
     (
       t@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, constraints@Constraints(subquery-constraints), groupByClause, havingClause, _, _, _, _, _, _)), correlation)
     , (remaining-expressions-plus-varRefs, tableExpressions, allVariablesExceptFromOuterQuery)
-    ) -> (remaining-expressions-plus-varRefs', tableExpressions', allVariablesExceptFromOuterQuery')
+    ) -> (remaining-expressions-plus-varRefs'', tableExpressions', allVariablesExceptFromOuterQuery')
     with new-variables := <filter(?ExpAsVar(_, _, _, <id>))> expAsVars
        ; visible-variables-to-predicates := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery, new-variables)
-       ; (pushed-down-predicates, remaining-expressions-plus-varRefs') := <foldl(try-push-down-predicate(|visible-variables-to-predicates))> (remaining-expressions-plus-varRefs, ([], []))
+       ; (pushed-down-predicates, remaining-expressions-plus-varRefs'') := <foldl(try-push-down-predicate(|visible-variables-to-predicates))> (remaining-expressions-plus-varRefs, ([], []))
        ; pushed-down-predicates' := <alltd(replace-varRef-with-expression(|expAsVars))> pushed-down-predicates
        ; if <(?CreateOneGroup() + ?Some(GroupByClause(_))); !pushed-down-predicates'; not(?[])> groupByClause // add to HAVING clause if there is a GROUP BY and predicates to pushdown are not empty
          then constraints' := constraints
@@ -155,3 +162,11 @@ rules
   replace-varRef-with-expression(|expAsVars):
     VarRef(_, v) -> exp
     where exp := <fetch-elem(?ExpAsVar(ExpressionPlusType(<id>, _), _, _, v))> expAsVars
+
+  vertex-correlates-to-vertex-projected-by-lateral-subquery(|vertices-projected-by-laterals):
+    t@Vertex(_, _, Correlation(ExpressionPlusType(VarRef(_, v), _))) -> t
+    where <oncetd(?v)> vertices-projected-by-laterals
+
+  dereference-vertex-correlation(|vertexCorrelations):
+    VarRef(identifier, v) -> VarRef(identifier, v')
+    where <oncetd(?Vertex(_, v, Correlation(ExpressionPlusType(VarRef(_, v'), _))))> vertexCorrelations


### PR DESCRIPTION
Push down predicates into LATERAL subquery even if the predicates reference correlated vertices.

PGQL version 2.0.1.8