### PR TITLE
Translate SELECT * in combination with LATERAL ( SELECT n.* even if no metadata is provided

### DIFF
--- a/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
@@ -875,7 +875,7 @@ public class SpoofaxAstToGraphQuery {
       TranslationContext ctx) {
 
     for (QueryVariable var : variables) {
-      if (var.isAnonymous()) {
+      if (var.getName().contains(GENERATED_VAR_SUBSTR)) {
         String name = var.getName().replace(GENERATED_VAR_SUBSTR, "anonymous");
         while (ctx.isVariableNameInUse(name)) {
           name += "_2";
@@ -934,6 +934,7 @@ public class SpoofaxAstToGraphQuery {
       expAsVars.add(expAsVar);
       ctx.addVar(expAsVar, varName, originOffset);
     }
+    giveAnonymousVariablesUniqueHiddenName(expAsVars, ctx);
     return expAsVars;
   }
 

--- a/pgql-spoofax/.classpath
+++ b/pgql-spoofax/.classpath
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+    <attributes>
+      <attribute name="maven.pomderived" value="true"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+    <attributes>
+      <attribute name="maven.pomderived" value="true"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="lib" path="target/replicate/str2libs"/>
+  <classpathentry kind="src" output="target/classes" path="src/main/strategies">
+    <attributes>
+      <attribute name="optional" value="true"/>
+      <attribute name="maven.pomderived" value="true"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="src" output="target/classes" path="src-gen/java">
+    <attributes>
+      <attribute name="optional" value="true"/>
+      <attribute name="maven.pomderived" value="true"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/pgql-spoofax/trans/analysis.str
+++ b/pgql-spoofax/trans/analysis.str
@@ -25,7 +25,14 @@ imports
 
 rules // Analysis
 
-  editor-analyze = analyze-all(normalize-before; add-names; add-types; normalize-after, id, id|<language>); reorder-error-messages
+  editor-analyze:
+    ast -> result
+    with variable-counter := <new-counter>
+       ; result := <analyze-all( normalize-before(|variable-counter)
+                               ; add-names(|variable-counter)
+                               ; add-types
+                               ; normalize-after
+                 , id, id|<language>); reorder-error-messages> ast
 
   reorder-error-messages = Result([FileResult(id,id,id,reorder-error-messages-helper,id, id)], id, id, id, id)
 
@@ -53,26 +60,30 @@ rules // Debugging
   debug-show-normalized:
     (_, _, ast, path, _) -> (filename, result)
     with
+      variable-counter := <new-counter>;
       filename := <guarantee-extension(|"normalized.aterm")> path;
-      result   := <normalize-before> ast
+      result   := <normalize-before(|variable-counter)> ast
 
   debug-show-normalized-with-names:
     (_, _, ast, path, _) -> (filename, result)
     with
+      variable-counter := <new-counter>;
       filename := <guarantee-extension(|"normalized.aterm")> path;
-      result   := <normalize-before; add-names> ast
+      result   := <normalize-before(|variable-counter); add-names(|variable-counter)> ast
 
   debug-show-normalized-with-types:
     (_, _, ast, path, _) -> (filename, result)
     with
+      variable-counter := <new-counter>;
       filename := <guarantee-extension(|"normalized.aterm")> path;
-      result   := <normalize-before; add-names; add-types> ast
+      result   := <normalize-before(|variable-counter); add-names(|variable-counter); add-types> ast
 
   debug-show-normalized-full:
     (_, _, ast, path, _) -> (filename, result)
     with
+      variable-counter := <new-counter>;
       filename := <guarantee-extension(|"normalized.aterm")> path;
-      result   := <normalize-before; add-names; add-types; normalize-after> ast
+      result   := <normalize-before(|variable-counter); add-names(|variable-counter); add-types; normalize-after> ast
 
   debug-show-analyzed:
     (_, _, ast, path, _) -> (filename, result)

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -541,9 +541,7 @@ rules // MODIFY
 
   nabl-constraint(|ctx):
     PropertyExpressions(expAsVars) -> <fail>
-    with expAsVarsWithComplexExpressions := <remove-all(?ExpAsVar(VarRef(Identifier(_, _)), _) + ?ExpAsVar(Cast(VarRef(Identifier(_, _)), _), _))> expAsVars
-       ; <batch-generate-error(|ctx, "Only column references and simple CAST expressions allowed; arbitrary expressions are not yet supported")> expAsVarsWithComplexExpressions
-       ; complexExpressionsWithoutAlias := <remove-all(?ExpAsVar(VarRef(_), _) + ?ExpAsVar(_, Identifier(_, _)))> expAsVars
+    with complexExpressionsWithoutAlias := <remove-all(?ExpAsVar(VarRef(_), _) + ?ExpAsVar(_, Identifier(_, _)))> expAsVars
        ; <batch-generate-error(|ctx, "Alias required (.. AS name)")> complexExpressionsWithoutAlias
        ; propertyNames := <filter(?ExpAsVar(_, Identifier(<id>, _)))> expAsVars
        ; <generate-error-on-duplicates(|ctx, "Duplicate property name")> propertyNames

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -882,7 +882,7 @@ rules // GRAPH_TABLE
 
   check-GraphTable-restriction(|ctx):
     t -> <fail>
-    where exp := <get-exp-from-aggregation; debug; (?ExpressionPlusType(_, Type("VERTEX")) + ?ExpressionPlusType(_, Type("EDGE")))> t
+    where exp := <get-exp-from-aggregation; (?ExpressionPlusType(_, Type("VERTEX")) + ?ExpressionPlusType(_, Type("EDGE")))> t
     with <generate-error(|ctx, "GRAPH_TABLE restriction: aggregation does not allow vertex or edge input; use the vertex/edge identifier or a property instead")> exp
 
   nabl-constraint(|ctx):

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -31,7 +31,7 @@ rules
 
   trans-query(|variables, metadata):
     NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables) ->
-        (NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions'', whereClause', groupBy', having', orderBy', limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables), variables-in-projection)
+        (NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions''', whereClause', groupBy', having', orderBy', limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables), variables-in-projection)
     with variables' := <guarantee-size-two-or-more> variables
 
        // PATH
@@ -56,12 +56,13 @@ rules
 
        // SELECT / INSERT / UPDATE / DELETE
        ; if <?SelectClause(_, _)> selectOrModifyClause
-         then (selectOrModifyClause', variables'''') := <resolve-select-clause(|variables''', metadata, valueExpression', tableExpressions', groupByExps)> selectOrModifyClause
+         then (selectOrModifyClause', variables'''', tableExpressions'') := <resolve-select-clause(|variables''', metadata, valueExpression', tableExpressions', groupByExps)> selectOrModifyClause
          else selectOrModifyClause' := <resolve-modify-clause(|variables''', metadata)> selectOrModifyClause
-           ; variables'''' := variables'''
+            ; variables'''' := variables'''
+            ; tableExpressions'' := tableExpressions'
          end
 
-       ; tableExpressions'' := <map(try(normalize-ANY-paths(|variables'''')))> tableExpressions' // normalize ANY either to REACHES or SHORTEST
+       ; tableExpressions''' := <map(try(normalize-ANY-paths(|variables'''')))> tableExpressions'' // normalize ANY either to REACHES or SHORTEST
 
        // HAVING
        ; having' := <resolve-having(|variables''', variables'''', metadata)> having // having resolves to GROUP BY variables first, then to SELECT variables
@@ -172,7 +173,7 @@ rules
        ; variables' := [vars'|variables]
 
   resolve-select-clause(|variables, metadata, valueExpression, tableExpressions, group-exps):
-    t@SelectClause(distinct, t2@SelectList(selectElements)) -> (selectClause', variables')
+    t@SelectClause(distinct, t2@SelectList(selectElements)) -> (selectClause', variables', tableExpressions)
     with varsInCurrentScope := <Hd> variables
        ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, valueExpression))> (selectElements, ([], varsInCurrentScope))
        ; selectElements'' := <origin-track-forced(!SelectList(selectElements'))> t2
@@ -180,30 +181,56 @@ rules
        ; selectClause' := <origin-track-forced(!SelectClause(distinct, selectElements''))> t
 
   resolve-select-clause(|variables, metadata, valueExpression, tableExpressions, group-exps):
-    t@SelectClause(distinct, star@Star()) -> (selectClause', variables')
+    t@SelectClause(distinct, star@Star()) -> (selectClause', variables', tableExpressions')
     with if [] := group-exps
-         then vars := <map(extract-variables-for-select-star); concat; make-set;
-                       filter(Identifier(is-string; not(is-substring(GENERATED)), id))> tableExpressions;
-              selectElements := <map(generate-ExpAsVar(|star))> vars
+         then selectElements := <map(extract-variables-for-select-star(|star)); concat; make-set> tableExpressions
             ; varsInCurrentScope := <Hd> variables
             ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, valueExpression))> (selectElements, ([], varsInCurrentScope))
             ; variables' := [vars'|<Tl> variables]
             ; star' := star
+            ; tableExpressions' := <map(replace-all-AllProperties)> tableExpressions // replace n.* in LATERAL or GRAPH_TABLE subqueries with a projection of n as we've pulled it up at this point
          else star' := <origin-track-forced(!GroupBySelectStar())> star // can't use GROUP BY in combination with SELECT *, we'll generate an error later
             ; selectElements' := []
             ; variables' := variables
+            ; tableExpressions' := tableExpressions
          end
        ; selectList := <origin-track-forced(!SelectList(selectElements'))> star
        ; selectClause' := <origin-track-forced(!SelectClause(star', selectList))> t
 
-  extract-variables-for-select-star = ?GraphPattern(_, _, _)
-                                    ; collect-in-outer-query(?Vertex(<id>, _, _) + ?Edge(_, <id>, _, _, _, _))
+  extract-variables-for-select-star(|star) = ?GraphPattern(_, _, _)
+                                           ; collect-in-outer-query(?Vertex(<id>, _, _) + ?Edge(_, <id>, _, _, _, _))
+                                           ; filter(is-anonymous-variable)
+                                           ; map(generate-ExpAsVar(|star))
 
-  extract-variables-for-select-star = ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)
-                                    ; map(
-                                        ?AllProperties(_, _); ![] + // no metadata was available to translate the n.*
-                                        ?ExpAsVar(_, <id>, _, _)
-                                      )
+  extract-variables-for-select-star(|star) = ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)
+                                           ; filter(
+                                               ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
+                                               pull-up-AllProperties // no metadata was available to translate the n.* so we pull it up
+                                             )
+
+  is-anonymous-variable = Identifier(is-string; not(is-substring(GENERATED)), id)
+
+  pull-up-AllProperties:
+    t@AllProperties(VarRef(iden, _), prefix) -> result
+    with name := <unique-name-for-AllProperties> t
+       ; identifier := <origin-track-forced(!Identifier(name, name))> t
+       ; originOffset := <origin-offset> t
+       ; result := <origin-track-forced(!AllProperties(VarRef(identifier, originOffset), prefix))> t
+
+  replace-all-AllProperties = ?GraphPattern(_, _, _)
+
+  replace-all-AllProperties = DerivedTable(id, Subquery(NormalizedQuery(id, replace-AllProperties-in-Select, id, id, id, id, id, id, id, id, id, id, id)), id)
+
+  replace-AllProperties-in-Select = origin-track-forced(SelectClause(id, SelectList(map(try(replace-AllProperties)))))
+
+  replace-AllProperties:
+    t@AllProperties(varRef, prefix) -> result
+    with name := <unique-name-for-AllProperties> t
+       ; identifier := <origin-track-forced(!Identifier(name, name))> t
+       ; originOffset := <origin-offset> t
+       ; result := <origin-track-forced(!ExpAsVar(varRef, identifier, NonAnonymous(), originOffset))> t
+
+  unique-name-for-AllProperties = origin-track-forced(!(".*_", <origin-offset; write-to-string>); conc-strings)
 
   resolve-modify-clause(|variables, metadata):
     t@ModifyClause(modifications) -> modifyClause'
@@ -283,12 +310,15 @@ rules
 
   resolve-exp-as-var-in-select(|variables, metadata, valueExpression):
     (t@AllProperties(varRef, columnNamePrefix), (result, vars)) -> (result', vars')
-    with varRef' := <resolve-var-ref(|variables, metadata)> varRef
+    with varRef' := <try(resolve-var-ref(|variables, metadata))> varRef
        ; if <?VarRef(v)> varRef'
          then selectElems := [ExpAsVar(varRef', v, Anonymous(), None())] // create a dummy ExpAsVar just to make sure an "unresolved variable" error will be generated
             ; vars' := vars
-         else elementType := <get-type-from-varRef-as-var(|variables)> varRef'
-            ; allLabels := <?Type("VERTEX"); !metadata; fetch-elem(?VertexLabels(<id>)) <+ ?Type("EDGE"); !metadata; fetch-elem(?EdgeLabels(<id>)) <+ !None()> elementType
+         else if <has-label-metadata> metadata
+              then elementType := <get-type-from-varRef-as-var(|variables) <+ !None()> varRef'
+                 ; allLabels := <?Type("VERTEX"); !metadata; fetch-elem(?VertexLabels(<id>)) <+ ?Type("EDGE"); !metadata; fetch-elem(?EdgeLabels(<id>)) <+ !None()> elementType
+              else allLabels := None()
+              end
             ; if <?None()> allLabels
               then selectElems := <resolve-var-refs(|variables, metadata)> [t] // no label metadata is provided so we don't process the n.* other than resolve variable n
                  ; vars' := vars
@@ -304,6 +334,8 @@ rules
               end
          end
        ; result' := <conc> (result, selectElems)
+
+  has-label-metadata = fetch-elem(?VertexLabels(_))
 
   generate-ExpAsVar(|star):
     t@Identifier(v, originText) -> expAsVar

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -23,32 +23,32 @@ imports
  */
 rules
 
-  add-names = is-ddl-statement
-              + ?AstPlusMetadata(query, metadata); !AstPlusMetadata(<trans-query(|[], metadata); ?(<id>, _)> query, metadata)
+  add-names(|variable-counter) = is-ddl-statement
+              + ?AstPlusMetadata(query, metadata); !AstPlusMetadata(<trans-query(|[], metadata, variable-counter); ?(<id>, _)> query, metadata)
               + ?Start-Plhdr() // for empty query string
 
 rules
 
-  trans-query(|variables, metadata):
+  trans-query(|variables, metadata, variable-counter):
     NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables) ->
         (NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions''', whereClause', groupBy', having', orderBy', limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables), variables-in-projection)
     with variables' := <guarantee-size-two-or-more> variables
 
        // PATH
-       ; pathExpressions' := <map(trans-path-expression(|variables', metadata))> pathExpressions
+       ; pathExpressions' := <map(trans-path-expression(|variables', metadata, variable-counter))> pathExpressions
 
        // these expAsVars are used to make the column aliases in SELECT visible in WHERE and GROUP BY
        ; expAsVars := <?SelectClause(_, SelectList(<id>)) <+ ![]> selectOrModifyClause
 
-       ; (tableExpressions', variables'', valueExpression') := <foldl(trans-table-expression(|metadata, expAsVars))> (tableExpressions, ([], variables', []))
+       ; (tableExpressions', variables'', valueExpression') := <foldl(trans-table-expression(|metadata, variable-counter, expAsVars))> (tableExpressions, ([], variables', []))
 
          // WHERE
-       ; whereClause' := <resolve-value-expression(|variables'', expAsVars, metadata)> whereClause
+       ; whereClause' := <resolve-value-expression(|variables'', expAsVars, metadata, variable-counter)> whereClause
 
        // GROUP BY
        ; if (!groupBy; ?Some(GroupByClause(groupByExps))) + (!selectOrModifyClause; create-one-group(|variables'')) + (!having; ?Some(_))
          then hasGroupBy := True()
-            ; (groupBy', variables''') := <resolve-group-by(|variables'', expAsVars, metadata)> groupBy
+            ; (groupBy', variables''') := <resolve-group-by(|variables'', expAsVars, metadata, variable-counter)> groupBy
          else hasGroupBy := False()
             ; (groupBy', variables''') := (groupBy, variables'')
             ; groupByExps := []
@@ -56,8 +56,8 @@ rules
 
        // SELECT / INSERT / UPDATE / DELETE
        ; if <?SelectClause(_, _)> selectOrModifyClause
-         then (selectOrModifyClause', variables'''', tableExpressions'') := <resolve-select-clause(|variables''', metadata, valueExpression', tableExpressions', groupByExps)> selectOrModifyClause
-         else selectOrModifyClause' := <resolve-modify-clause(|variables''', metadata)> selectOrModifyClause
+         then (selectOrModifyClause', variables'''', tableExpressions'') := <resolve-select-clause(|variables''', metadata, variable-counter, valueExpression', tableExpressions', groupByExps)> selectOrModifyClause
+         else selectOrModifyClause' := <resolve-modify-clause(|variables''', metadata, variable-counter)> selectOrModifyClause
             ; variables'''' := variables'''
             ; tableExpressions'' := tableExpressions'
          end
@@ -65,18 +65,18 @@ rules
        ; tableExpressions''' := <map(try(normalize-ANY-paths(|variables'''')))> tableExpressions'' // normalize ANY either to REACHES or SHORTEST
 
        // HAVING
-       ; having' := <resolve-having(|variables''', variables'''', metadata)> having // having resolves to GROUP BY variables first, then to SELECT variables
+       ; having' := <resolve-having(|variables''', variables'''', metadata, variable-counter)> having // having resolves to GROUP BY variables first, then to SELECT variables
 
        // ORDER BY
        // resolve to SELECT variables first, then to GROUP BY variables (except in case of a VarRef in a PropRef, in which case it is resolved to MATCH or GROUP BY first)
-       ; orderBy' := < resolve-var-refs(|variables'''', metadata)
-                     ; resolve-prop-refs(|variables''', metadata)
+       ; orderBy' := < resolve-var-refs(|variables'''', metadata, variable-counter)
+                     ; resolve-prop-refs(|variables''', metadata, variable-counter)
                      ; alltd(optimize-order-by)> orderBy
 
        // variables to pass into subsequent table expressions
        ; variables-in-projection := <diff> (<Hd> variables'''', <Hd> variables''')
 
-  trans-table-expression(|metadata, expAsVars):
+  trans-table-expression(|metadata, variable-counter, expAsVars):
     (GraphPattern(vertices, connections, Constraints(valueExpression)), (result, variables, valueExpressionPriorLateralQueries)) -> (result', variables', valueExpression'')
       with  // MATCH
            (vertices', connections') := <alltd(trans-elem(|variables))> (vertices, <alltd(trans-rows-per-match(|variables))> connections)
@@ -90,18 +90,18 @@ rules
           ; visible-groupVars := <replace-or-add-all> (new-groupVars, y)
           ; variables' := [visible-vars|[visible-groupVars|ys]]
 
-          ; connections'' := <alltd(resolve-var-refs-in-path-expression(|variables', metadata))> connections'
+          ; connections'' := <alltd(resolve-var-refs-in-path-expression(|variables', metadata, variable-counter))> connections'
 
           // local WHERE clause for has_label constraints and future inlined constraints
-          ; valueExpression' := <resolve-value-expression(|variables', expAsVars, metadata)> valueExpression
+          ; valueExpression' := <resolve-value-expression(|variables', expAsVars, metadata, variable-counter)> valueExpression
 
           ; graphPattern' := GraphPattern(vertices', connections'', Constraints(valueExpression'))
           ; result' := <conc> (result, [graphPattern'])
           ; valueExpression'' := <conc> (valueExpressionPriorLateralQueries, valueExpression') // for SELECT n.* we need to have all the label expression
 
-  trans-table-expression(|metadata, expAsVars):
+  trans-table-expression(|metadata, variable-counter, expAsVars):
     (derivedTable@DerivedTable(lateral, subquery@Subquery(normalizedQuery), correlation), (result, variables, valueExpressionPriorLateralQueries)) -> (result', variables', valueExpression')
-    with (normalizedQuery', variables-in-projection) := <trans-query(|variables, metadata)> normalizedQuery
+    with (normalizedQuery', variables-in-projection) := <trans-query(|variables, metadata, variable-counter)> normalizedQuery
        ; subquery' := <origin-track-forced(!Subquery(normalizedQuery'))> subquery
        ; derivedTable' := <origin-track-forced(!DerivedTable(lateral, subquery', correlation))> derivedTable
        ; result' := <conc> (result, [derivedTable'])
@@ -158,37 +158,39 @@ rules
          else varDefs' := <conc> (varDefs, [vd])
          end
 
-  resolve-value-expression(|variables, expAsVars, metadata):
+  resolve-value-expression(|variables, expAsVars, metadata, variable-counter):
     valueExpression -> valueExpression'
-    with valueExpression' := <resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVars, metadata)> valueExpression
+    with valueExpression' := <resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVars, metadata, variable-counter)> valueExpression
 
-  resolve-group-by(|variables, expAsVarsFromSelectClause, metadata):
+  resolve-group-by(|variables, expAsVarsFromSelectClause, metadata, variable-counter):
     Some(GroupByClause(expAsVars)) -> (Some(GroupByClause(expAsVars')), variables')
-    with (expAsVars', vars') := <foldl(resolve-exp-as-var-in-group-by(|variables, expAsVarsFromSelectClause, metadata))> (expAsVars, ([], []))
+    with (expAsVars', vars') := <foldl(resolve-exp-as-var-in-group-by(|variables, expAsVarsFromSelectClause, metadata, variable-counter))> (expAsVars, ([], []))
        ; variables' := [vars'|variables]
 
-  resolve-group-by(|variables, expAsVars, metadata):
+  resolve-group-by(|variables, expAsVars, metadata, variable-counter):
     None() -> (CreateOneGroup(), variables')
     with vars' := []
        ; variables' := [vars'|variables]
 
-  resolve-select-clause(|variables, metadata, valueExpression, tableExpressions, group-exps):
+  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps):
     t@SelectClause(distinct, t2@SelectList(selectElements)) -> (selectClause', variables', tableExpressions)
     with varsInCurrentScope := <Hd> variables
-       ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, valueExpression))> (selectElements, ([], varsInCurrentScope))
+       ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression))> (selectElements, ([], varsInCurrentScope))
        ; selectElements'' := <origin-track-forced(!SelectList(selectElements'))> t2
        ; variables' := [vars'|<Tl> variables]
        ; selectClause' := <origin-track-forced(!SelectClause(distinct, selectElements''))> t
 
-  resolve-select-clause(|variables, metadata, valueExpression, tableExpressions, group-exps):
+  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps):
     t@SelectClause(distinct, star@Star()) -> (selectClause', variables', tableExpressions')
     with if [] := group-exps
-         then selectElements := <map(extract-variables-for-select-star(|star)); concat; make-set> tableExpressions
+         then variable-counter-copy := <new-counter>
+            ; <set-counter> (variable-counter-copy, <get-counter> variable-counter) // create a copy of the variable counter as we will use one for references and one for definitions
+            ; selectElements := <map(extract-variables-for-select-star(|star, variable-counter)); concat; make-set> tableExpressions
             ; varsInCurrentScope := <Hd> variables
-            ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, valueExpression))> (selectElements, ([], varsInCurrentScope))
+            ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression))> (selectElements, ([], varsInCurrentScope))
             ; variables' := [vars'|<Tl> variables]
             ; star' := star
-            ; tableExpressions' := <map(replace-all-AllProperties)> tableExpressions // replace n.* in LATERAL or GRAPH_TABLE subqueries with a projection of n as we've pulled it up at this point
+            ; tableExpressions' := <map(replace-all-AllProperties(|variable-counter-copy))> tableExpressions // replace n.* in LATERAL or GRAPH_TABLE subqueries with a projection of n as we've pulled it up at this point
          else star' := <origin-track-forced(!GroupBySelectStar())> star // can't use GROUP BY in combination with SELECT *, we'll generate an error later
             ; selectElements' := []
             ; variables' := variables
@@ -197,66 +199,66 @@ rules
        ; selectList := <origin-track-forced(!SelectList(selectElements'))> star
        ; selectClause' := <origin-track-forced(!SelectClause(star', selectList))> t
 
-  extract-variables-for-select-star(|star) = ?GraphPattern(_, _, _)
-                                           ; collect-in-outer-query(?Vertex(<id>, _, _) + ?Edge(_, <id>, _, _, _, _))
-                                           ; filter(is-anonymous-variable)
-                                           ; map(generate-ExpAsVar(|star))
+  extract-variables-for-select-star(|star, variable-counter) =
+      ?GraphPattern(_, _, _)
+    ; collect-in-outer-query(?Vertex(<id>, _, _) + ?Edge(_, <id>, _, _, _, _))
+    ; filter(is-anonymous-variable)
+    ; map(generate-ExpAsVar(|star))
 
-  extract-variables-for-select-star(|star) = ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)
-                                           ; filter(
-                                               ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
-                                               pull-up-AllProperties // no metadata was available to translate the n.* so we pull it up
-                                             )
+  extract-variables-for-select-star(|star, variable-counter) =
+      ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)
+    ; filter(
+        ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
+        pull-up-AllProperties(|variable-counter) // no metadata was available to translate the n.* so we pull it up
+      )
 
   is-anonymous-variable = Identifier(is-string; not(is-substring(GENERATED)), id)
 
-  pull-up-AllProperties:
+  pull-up-AllProperties(|variable-counter):
     t@AllProperties(VarRef(iden, _), prefix) -> result
-    with name := <unique-name-for-AllProperties> t
+    with name := <unique-name(|variable-counter, t)>
        ; identifier := <origin-track-forced(!Identifier(name, name))> t
        ; originOffset := <origin-offset> t
        ; result := <origin-track-forced(!AllProperties(VarRef(identifier, originOffset), prefix))> t
 
-  replace-all-AllProperties = ?GraphPattern(_, _, _)
+  replace-all-AllProperties(|variable-counter) = ?GraphPattern(_, _, _)
 
-  replace-all-AllProperties = DerivedTable(id, Subquery(NormalizedQuery(id, replace-AllProperties-in-Select, id, id, id, id, id, id, id, id, id, id, id)), id)
+  replace-all-AllProperties(|variable-counter) = DerivedTable(id, Subquery(NormalizedQuery(id, replace-AllProperties-in-Select(|variable-counter), id, id, id, id, id, id, id, id, id, id, id)), id)
 
-  replace-AllProperties-in-Select = origin-track-forced(SelectClause(id, SelectList(map(try(replace-AllProperties)))))
+  replace-AllProperties-in-Select(|variable-counter) = origin-track-forced(SelectClause(id, SelectList(map(try(replace-AllProperties(|variable-counter))))))
 
-  replace-AllProperties:
+  replace-AllProperties(|variable-counter):
     t@AllProperties(varRef, prefix) -> result
-    with name := <unique-name-for-AllProperties> t
+    with name := <unique-name(|variable-counter, t)>
        ; identifier := <origin-track-forced(!Identifier(name, name))> t
        ; originOffset := <origin-offset> t
        ; result := <origin-track-forced(!ExpAsVar(varRef, identifier, NonAnonymous(), originOffset))> t
 
-  unique-name-for-AllProperties = origin-track-forced(!(".*_", <origin-offset; write-to-string>); conc-strings)
-
-  resolve-modify-clause(|variables, metadata):
+  resolve-modify-clause(|variables, metadata, variable-counter):
     t@ModifyClause(modifications) -> modifyClause'
     with varsInCurrentScope := <Hd> variables
-       ; modifications' := <map(resolve-modification(|variables, metadata))> modifications
+       ; modifications' := <map(resolve-modification(|variables, metadata, variable-counter))> modifications
        ; modifyClause' := <origin-track-forced(!ModifyClause(modifications'))> t
 
-  resolve-modification(|variables, metadata):
+  resolve-modification(|variables, metadata, variable-counter):
     t@InsertClause(graphName, insertions) -> insertClause'
-    with (insertions', _) := <foldl(resolve-insertion(|variables, metadata))> (insertions, ([], variables))
+    with (insertions', _) := <foldl(resolve-insertion(|variables, metadata, variable-counter))> (insertions, ([], variables))
        ; insertClause' := <origin-track-forced(!InsertClause(graphName, insertions'))> t
 
-  resolve-modification(|variables, metadata) = ?UpdateClause(_); resolve-var-refs(|variables, metadata)
+  resolve-modification(|variables, metadata, variable-counter) = ?UpdateClause(_); resolve-var-refs(|variables, metadata, variable-counter)
 
-  resolve-modification(|variables, metadata) = ?DeleteClause(_); resolve-var-refs(|variables, metadata)
+  resolve-modification(|variables, metadata, variable-counter) = ?DeleteClause(_); resolve-var-refs(|variables, metadata, variable-counter)
 
-  resolve-insertion(|original-variables, metadata):
+  resolve-insertion(|original-variables, metadata, variable-counter):
     (t, (result, variables)) -> (result', variables')
     where <?VertexInsertion(iden@Identifier(v, _), labels, properties) + ?DirectedEdgeInsertion(iden@Identifier(v, _), src, dst, labels, properties)> t
     with originOffset := <origin-offset> v
-       ; properties' := <resolve-set-properties(|v, originOffset, original-variables, metadata)> properties
+       ; properties' := <resolve-set-properties(|v, originOffset, original-variables, metadata, variable-counter)> properties
        ; if <?VertexInsertion(_, _, _)> t
          then insertion := <origin-track-forced(!VertexInsertion(iden, originOffset, labels, properties'))> t
             ; type := Type("VERTEX")
-         else src' := <resolve-var-refs(|variables, metadata)> src
-            ; dst' := <resolve-var-refs(|variables, metadata)> dst
+         else src' := <resolve-var-refs(|variables, metadata, variable-counter)> src
+            ; dst' := <resolve-var-refs(|variables, metadata, variable-counter)> dst
             ; insertion := <origin-track-forced(!DirectedEdgeInsertion(iden, originOffset, src', dst', labels, properties'))> t
             ; type := Type("EDGE")
          end
@@ -265,17 +267,17 @@ rules
        ; variables' := [vars-in-scope'|xs]
        ; result' := <conc> (result, [insertion])
 
-  resolve-set-properties(|v, originOffset, original-variables, metadata) = ?None() + Some(Properties(map(resolve-set-property(|v, originOffset, original-variables, metadata))))
+  resolve-set-properties(|v, originOffset, original-variables, metadata, variable-counter) = ?None() + Some(Properties(map(resolve-set-property(|v, originOffset, original-variables, metadata, variable-counter))))
 
-  resolve-set-property(|v, originOffset, original-variables, metadata):
+  resolve-set-property(|v, originOffset, original-variables, metadata, variable-counter):
     t@SetProperty(PropRef(varRef, prop), exp) -> result
-    with varRef' := <?VarRef(Identifier(v, _)); ?VarRef(<id>); !VarRef(<id>, originOffset) <+ resolve-var-refs(|original-variables, metadata)> varRef
-       ; exp' :=  <origin-track-forced(resolve-var-refs(|original-variables, metadata))> exp
+    with varRef' := <?VarRef(Identifier(v, _)); ?VarRef(<id>); !VarRef(<id>, originOffset) <+ resolve-var-refs(|original-variables, metadata, variable-counter)> varRef
+       ; exp' :=  <origin-track-forced(resolve-var-refs(|original-variables, metadata, variable-counter))> exp
        ; result := <origin-track-forced(!SetProperty(PropRef(varRef', prop), exp'))> t
 
-  resolve-exp-as-var-in-group-by(|variables, expAsVarsFromSelectClause, metadata):
+  resolve-exp-as-var-in-group-by(|variables, expAsVarsFromSelectClause, metadata, variable-counter):
     (t@ExpAsVar(exp, iden@Identifier(v, _), anonymous), (result, vars)) -> (result', vars')
-    with exp' := <resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVarsFromSelectClause, metadata)> exp
+    with exp' := <resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVarsFromSelectClause, metadata, variable-counter)> exp
        ; replaced-groupByExp-with-selectExp := <alltd(?VarRef(<id>, _); !VarRef(<id>))> exp'
        ; originOffset := <origin-offset> v
        ; type := <get-type-from-varRef-as-var(|variables)> exp'
@@ -288,9 +290,9 @@ rules
     (exp1, exp2) -> <id>
     where <not(eq)> (exp1, exp2)
 
-  resolve-exp-as-var-in-select(|variables, metadata, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
     (t@ExpAsVar(exp, iden@Identifier(v, _), anonymous), (result, vars)) -> (result', vars')
-    with exp' := <resolve-var-refs(|variables, metadata)> exp
+    with exp' := <resolve-var-refs(|variables, metadata, variable-counter)> exp
        ; originOffset := <origin-offset> v
        ; if <?Anonymous(); !v; origin-text; ?"*"> anonymous
          then // in case of SELECT * make sure each ExpAsVar gets a unique origin assigned
@@ -303,14 +305,14 @@ rules
        ; result' := <conc> (result, [expAsVar'])
 
   // expression was defined in GROUP BY and doesn't need to be resolved again
-  resolve-exp-as-var-in-select(|variables, metadata, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
      (expAsVar@ExpAsVar(_, _, _, originOffset), (result, vars)) -> (result', vars')
      with vars' := vars // it was already added during GROUP BY analysis
         ; result' := <conc> (result, [expAsVar])
 
-  resolve-exp-as-var-in-select(|variables, metadata, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
     (t@AllProperties(varRef, columnNamePrefix), (result, vars)) -> (result', vars')
-    with varRef' := <try(resolve-var-ref(|variables, metadata))> varRef
+    with varRef' := <try(resolve-var-ref(|variables, metadata, variable-counter))> varRef
        ; if <?VarRef(v)> varRef'
          then selectElems := [ExpAsVar(varRef', v, Anonymous(), None())] // create a dummy ExpAsVar just to make sure an "unresolved variable" error will be generated
             ; vars' := vars
@@ -320,7 +322,7 @@ rules
               else allLabels := None()
               end
             ; if <?None()> allLabels
-              then selectElems := <resolve-var-refs(|variables, metadata)> [t] // no label metadata is provided so we don't process the n.* other than resolve variable n
+              then selectElems := <resolve-var-refs(|variables, metadata, variable-counter)> [t] // no label metadata is provided so we don't process the n.* other than resolve variable n
                  ; vars' := vars
               else originOffset := <?VarRef(_, <id>) <+ !None()> varRef'
                  ; labelExpression := <filter(simplify-label-expression(|originOffset)); (?[]; !All() <+ to-label-conjunction)> valueExpression
@@ -364,16 +366,16 @@ rules
   generated-exp-as-vars-to-varDef(|elementType):
     ExpAsVar(propRef, var, anonymous, originOffset) -> VarDef(var, originOffset, None(), None(), propRef, ThisQuery(), elementType)
 
-  resolve-having(|variables-after-group-by, variables-after-select, metadata):
+  resolve-having(|variables-after-group-by, variables-after-select, metadata, variable-counter):
     having -> having'
     with [x|xs] := variables-after-select
        ; [y|_] := variables-after-group-by
        ; z := <replace-or-add-all> (y, x)
        ; variables := [z|xs]
-       ; having' := <resolve-var-refs(|variables, metadata)> having
+       ; having' := <resolve-var-refs(|variables, metadata, variable-counter)> having
 
-  resolve-var-refs(|variables, metadata) =
-      alltd(resolve-var-ref(|variables, metadata))
+  resolve-var-refs(|variables, metadata, variable-counter) =
+      alltd(resolve-var-ref(|variables, metadata, variable-counter))
     ; detect-common-subexpressions(|variables)
 
   /*
@@ -392,25 +394,25 @@ rules
         Actual query: SELECT n.age + 2 AS v FROM MATCH (n) GROUP BY v
         Final AST:    SELECT v FROM MATCH (n) GROUP BY n.age + 2 AS v
   */
-  resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVarsFromSelectClause, metadata) =
+  resolve-var-refs-and-use-expAsVarsFromSelectClause(|variables, expAsVarsFromSelectClause, metadata, variable-counter) =
       alltd-in-outer-query-outside-aggregation( resolve-var-ref-within-query(|variables, expAsVarsFromSelectClause);
-                                                try(replace-ref-with-exp(|variables, expAsVarsFromSelectClause, metadata)))
-    ; alltd(resolve-var-ref(|variables, metadata)) // now also resolve subqueries and also resolve to variables from outer query
+                                                try(replace-ref-with-exp(|variables, expAsVarsFromSelectClause, metadata, variable-counter)))
+    ; alltd(resolve-var-ref(|variables, metadata, variable-counter)) // now also resolve subqueries and also resolve to variables from outer query
     ; detect-common-subexpressions(|variables)
 
   detect-common-subexpressions(|variables) =
       alltd(replace-exp-with-ref-within-this-query(|variables) <+ is-subquery <+ is-aggregate)
     ; alltd(replace-exp-with-ref-from-outer-queries(|variables) <+ is-subquery <+ is-aggregate)
 
-  resolve-var-refs-in-path-expression(|variables, metadata):
+  resolve-var-refs-in-path-expression(|variables, metadata, variable-counter):
     t@Path(_, _, _, quantifier, _, _, _, _, _, _) -> t'
     with [_|variables'] := variables
        ; if <has-at-most-one-binding> quantifier
-       then t' := <alltd(resolve-var-ref(|variables, metadata))> t // resolve only to singleton variables
-       else t' := <alltd(resolve-var-ref(|variables', metadata) + resolve-var-ref(|variables, metadata))> t // resolve to either group variables or singleton variables
+       then t' := <alltd(resolve-var-ref(|variables, metadata, variable-counter))> t // resolve only to singleton variables
+       else t' := <alltd(resolve-var-ref(|variables', metadata, variable-counter) + resolve-var-ref(|variables, metadata, variable-counter))> t // resolve to either group variables or singleton variables
         end
 
-  resolve-var-ref(|variables, metadata):
+  resolve-var-ref(|variables, metadata, variable-counter):
     t@VarRef(iden@Identifier(v, _)) -> varRef
     with varRef := <
            Hd; fetch(?VarDef(Identifier(v, _), origin-offset, _, _, _, _, _)); !t; origin-track-forced(!VarRef(iden, origin-offset))
@@ -425,7 +427,7 @@ rules
            <+ !VarRef(iden)
          > variables
 
-  resolve-var-ref(|variables, metadata):
+  resolve-var-ref(|variables, metadata, variable-counter):
     t@PropRef(VarRef(iden@Identifier(v, _)), prop) -> PropRef(varRef, prop)
     with varRef := <
            Hd
@@ -442,18 +444,18 @@ rules
       > variables
 
   // MIN, MAX, SUM, AVG, ...
-  resolve-var-ref(|variables, metadata):
+  resolve-var-ref(|variables, metadata, variable-counter):
     aggr -> <origin-track-forced(!aggr')> aggr
     where <is-aggregate> aggr
     with (cons, arguments) := <explode-term> aggr
        ; variables' := <Tl> variables
-       ; arguments' :=  <resolve-var-refs(|variables', metadata)> arguments
+       ; arguments' :=  <resolve-var-refs(|variables', metadata, variable-counter)> arguments
        ; aggr' := <mkterm> (cons, arguments')
 
-  resolve-var-ref(|variables, metadata):
+  resolve-var-ref(|variables, metadata, variable-counter):
     Subquery(query) -> Subquery(query')
     with variables' := <alltd(VarDef(id, id, id, id, id, !OuterQuery(), id))> variables
-       ; (query', _) := <trans-query(|variables', metadata)> query
+       ; (query', _) := <trans-query(|variables', metadata, variable-counter)> query
 
   replace-exp-with-ref-within-this-query(|variables):
     exp -> varRef
@@ -491,16 +493,16 @@ rules
 
   eq-ignore-case = alltd(?Identifier(<id>, _)); eq
 
-  replace-ref-with-exp(|variables, expAsVars, metadata):
+  replace-ref-with-exp(|variables, expAsVars, metadata, variable-counter):
     VarRef(Identifier(v, _)) -> resolved-exp
     where exp := <filter(?ExpAsVar(<id>, Identifier(v, _), NonAnonymous())); Hd> expAsVars
-    with resolved-exp := <alltd(resolve-var-ref(|variables, metadata))> exp
+    with resolved-exp := <alltd(resolve-var-ref(|variables, metadata, variable-counter))> exp
 
-  resolve-prop-refs(|variables, metadata) = alltd(resolve-prop-ref(|variables, metadata))
+  resolve-prop-refs(|variables, metadata, variable-counter) = alltd(resolve-prop-ref(|variables, metadata, variable-counter))
 
-  resolve-prop-ref(|variables, metadata):
+  resolve-prop-ref(|variables, metadata, variable-counter):
     t@PropRef(varRef@VarRef(_), prop) -> PropRef(varRef', prop)
-    with varRef' := <resolve-var-ref(|variables, metadata)> varRef
+    with varRef' := <resolve-var-ref(|variables, metadata, variable-counter)> varRef
 
   /*
      if the query has no GROUP BY but there are one ore more aggregations in the SELECT, then we generate an
@@ -521,7 +523,7 @@ rules
     t@VarRef(Identifier(v, _)) -> t
     where <oncetd(?VarDef(Identifier(v, _), _, _, _, _, _, _))> visible-vars
 
-  trans-path-expression(|variables, metadata):
+  trans-path-expression(|variables, metadata, variable-counter):
     CommonPathExpression(name, vertices, edges, valueExpression, costClause) -> CommonPathExpression(name, vertices', edges', valueExpression', costClause')
     with
        // pattern
@@ -532,9 +534,9 @@ rules
 
        // WHERE
        ; variables' := [visible-vars|xs]
-       ; valueExpression' := <resolve-value-expression(|variables', [], metadata)> valueExpression
+       ; valueExpression' := <resolve-value-expression(|variables', [], metadata, variable-counter)> valueExpression
 
-       ; costClause' := <resolve-value-expression(|variables', [], metadata)> costClause
+       ; costClause' := <resolve-value-expression(|variables', [], metadata, variable-counter)> costClause
 
   optimize-order-by:
     OrderByClause(elems) -> OrderByClause(elems')

--- a/pgql-spoofax/trans/normalize.str
+++ b/pgql-spoofax/trans/normalize.str
@@ -20,33 +20,32 @@ imports
 rules
 
   // CREATE PROPERTY GRAPH
-  normalize-before:
+  normalize-before(|variable-counter):
     ast -> <normalize-CreatePropertyGraph> ast
     where <is-CreatePropertyGraph> ast
 
   // DROP PROPERTY GRAPH
-  normalize-before:
+  normalize-before(|variable-counter):
     ast -> <normalize-DropPropertyGraph> ast
     where <is-DropPropertyGraph> ast
 
   // CREATE EXTERNAL SCHEMA
-  normalize-before:
+  normalize-before(|variable-counter):
     ast -> <normalize-CreateExternalSchema> ast
     where <is-CreateExternalSchema> ast
 
   // DROP EXTERNAL SCHEMA
-  normalize-before:
+  normalize-before(|variable-counter):
     ast -> <normalize-DropExternalSchema> ast
     where <is-DropExternalSchema> ast
 
   // SELECT, INSERT, UPDATE or DELETE
-  normalize-before:
+  normalize-before(|variable-counter):
     astPlusMetadata -> AstPlusMetadata(result, metadata)
     where <not(is-ddl-statement)> astPlusMetadata
     with
       ast := <try(?AstPlusMetadata(<id>, _))> astPlusMetadata; // AST does not always come with metadata
       metadata := <?AstPlusMetadata(_, <id>) <+ ![]> astPlusMetadata;
-      variable-counter := <new-counter>;
       bindVariable-counter := <new-counter>;
       error-messages := <
         (  is-pgql10; collect(get-pgql10-limitation)

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -41,21 +41,6 @@ test Duplicate vertex and edge tables [[
 ]] error like "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)" at #1, #2
    error like "Duplicate edge table name; use an alias to make the edge table name unique (table AS alias)" at #3, #4
 
-test Complex expressions as property not allowed [[
-
-  CREATE PROPERTY GRAPH myGraph
-    VERTEX TABLES (
-      Person PROPERTIES ( [["age" + "age" AS prop1,]] [[123 AS prop2]] )
-    )
-    EDGE TABLES (adsfad
-      knows
-        SOURCE Person
-        DESTINATION Person
-        PROPERTIES ( [[weight + 1 AS prop1 )]]
-    )
-
-]] error like "Only column references and simple CAST expressions allowed; arbitrary expressions are not yet supported" at #1, #2, #3
-
 test Missing property name [[
 
   CREATE PROPERTY GRAPH myGraph


### PR DESCRIPTION
This is needed for applications like GraphViz that do not provide metadata but still require SELECT * to be translated correctly into an equivalent query that does not contain SELECT *