### PR TITLE
Fix bug in ALL ELEMENT TABLES EXCEPT

### DIFF
--- a/pgql-lang/src/main/java/oracle/pgql/lang/TranslateCreatePropertyGraph.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/TranslateCreatePropertyGraph.java
@@ -54,6 +54,8 @@ public class TranslateCreatePropertyGraph {
 
   private static int BASE_ELEMENT_TABLE_ALIAS = 1;
 
+  private static int BASE_GRAPH_ELEMENT_TABLES_TABLES_EXCEPT = 0;
+
   private static int BASE_GRAPH_ELEMENT_TABLES_TABLES_EXCEPT_LIST = 0;
 
   private static int VERTEX_TABLES_TABLES_LIST = 0;
@@ -161,12 +163,12 @@ public class TranslateCreatePropertyGraph {
             }
             break;
           case "AllElementTables":
-            IStrategoTerm exceptElementTablesT = baseElementTablesT
-                .getSubterm(BASE_GRAPH_ELEMENT_TABLES_TABLES_EXCEPT_LIST);
-            
+            IStrategoTerm exceptElementTablesT = baseElementTablesT.getSubterm(BASE_GRAPH_ELEMENT_TABLES_TABLES_EXCEPT);
+
             if (!isNone(exceptElementTablesT)) {
               allElementTablesExcept = new ArrayList<String>();
-              for (IStrategoTerm exceptElementTableT : getSomeValue(exceptElementTablesT)) {
+              for (IStrategoTerm exceptElementTableT : getSomeValue(exceptElementTablesT)
+                  .getSubterm(BASE_GRAPH_ELEMENT_TABLES_TABLES_EXCEPT_LIST)) {
                 String exceptElementTable = getString(exceptElementTableT);
                 allElementTablesExcept.add(exceptElementTable);
               }

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 
-
+import oracle.pgql.lang.ddl.propertygraph.CreateSuperPropertyGraph;
 import oracle.pgql.lang.ir.ExpAsVar;
 import oracle.pgql.lang.ir.GraphQuery;
 import oracle.pgql.lang.ir.QueryExpression.AllProperties;
@@ -415,5 +415,14 @@ public class BugFixTest extends AbstractPgqlTest {
     PgqlResult result1 = pgql.parse("SELECT has_label(n, CASE WHEN has_label(m, 'PERSON') THEN 'CAR' ELSE 'HOUSE' END) FROM MATCH (n) -> (m)");
     PgqlResult result2 = pgql.parse("SELECT \"has_label\"(n, CASE WHEN \"has_label\"(m, 'PERSON') THEN 'CAR' ELSE 'HOUSE' END) FROM MATCH (n) -> (m)");
     assertEquals(result2.getGraphQuery().toString(), result1.getGraphQuery().toString());
+  }
+
+  @Test
+  public void testAllElementTablesExcept() throws Exception {
+    PgqlResult result = pgql.parse("CREATE PROPERTY GRAPH g1 BASE GRAPHS ( g2 ALL ELEMENT TABLES EXCEPT ( t1, t2 ) )");
+    CreateSuperPropertyGraph createPropertyGraph = (CreateSuperPropertyGraph) result.getPgqlStatement();
+    List<String> allEmentTablesExcept = createPropertyGraph.getBaseGraphs().get(0).getAllElementTablesExcept();
+    assertEquals("T1", allEmentTablesExcept.get(0));
+    assertEquals("T2", allEmentTablesExcept.get(1));
   }
 }


### PR DESCRIPTION
It was only keeping the first element in the except list instead of all elements.