### PR TITLE
remove incorrect error message for vertex table reference in base graph

### DIFF
--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -432,7 +432,7 @@ public class BugFixTest extends AbstractPgqlTest {
   }
 
   @Test
-  public void testReferenceVertexTableFromBaseGraph() throws Exception {
+  public void testReferenceVertexTableFromBaseGraph1() throws Exception {
     PgqlResult result = pgql.parse(
         "CREATE PROPERTY GRAPH g1 BASE GRAPHS ( g2 ) EDGE TABLES ( e1 SOURCE v1 DESTINATION KEY ( c1 ) REFERENCES v2 ( c2 ) )");
     assertTrue(result.isQueryValid());
@@ -443,5 +443,20 @@ public class BugFixTest extends AbstractPgqlTest {
 
     // make sure pretty printing does not fail and pretty printed statement can be parsed
     assertTrue(pgql.parse(result.getPgqlStatement().toString()).isQueryValid());
+  }
+
+  @Test
+  public void testReferenceVertexTableFromBaseGraph2() throws Exception {
+    PgqlResult result = pgql.parse(
+        "CREATE PROPERTY GRAPH g1 " + //
+        "  BASE GRAPHS( " + //
+        "   g2 ELEMENT TABLES( v1, v2 ) " + //
+        "  ) " + //
+        "  EDGE TABLES( " + //
+        "    e KEY(id) " + //
+        "    SOURCE KEY (sid) REFERENCES v1 (id) " + //
+        "    DESTINATION KEY (did) REFERENCES v2 (id) " + //
+        "  )");
+    assertTrue(result.isQueryValid());
   }
 }

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -536,8 +536,8 @@ rules // MODIFY
        ; <generate-error-on-duplicates(|ctx, "Duplicate element table name; use an alias to make the element table name unique (table AS alias)")> elementTableNames
 
        // check for unresolved references from edge tables to vertex tables
-       // we only do so if there are no base graphs or if there are base graphs but all their element tables are specified
-       ; if <?None() + ?Some(BaseGraphs(<id>)); not(fetch-elem(?BaseGraph(_, Some(AllElementTables(_))) + ?BaseGraph(_, None())))> baseGraphs
+       // we only do so if there are no base graphs
+       ; if <?None()> baseGraphs
          then vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
                                                   ?DestinationVertexTable(_, ReferencedVertexTable(Name(_, <id>), _))
                                                 ); to-identifier-without-origin-info)> edgeTables

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -527,7 +527,7 @@ rules // MODIFY
 
   nabl-constraint(|ctx):
     CreatePropertyGraph(_, baseGraphs, VertexTables(vertexTables), EdgeTables(edgeTables), _) -> <fail>
-    with elementTableNamesFromBaseGraphs := <collect-om(?BaseElementTable(_, <id>); to-identifier-without-origin-info)> baseGraphs
+    with elementTableNamesFromBaseGraphs := <collect-om(?BaseElementTable(_, <id>); to-identifier-without-origin-info, conc)> baseGraphs
        ; vertexTableNames := <map(?VertexTable(_, <id>, _, _); to-identifier-without-origin-info)> vertexTables
        ; <generate-error-on-duplicates(|ctx, "Duplicate vertex table name; use an alias to make the vertex table name unique (table AS alias)")> vertexTableNames
        ; edgeTableNames := <map(?EdgeTable(_, <id>, _, _, _, _); to-identifier-without-origin-info)> edgeTables
@@ -535,14 +535,17 @@ rules // MODIFY
        ; elementTableNames := <conc> (elementTableNamesFromBaseGraphs, <conc; make-set> (vertexTableNames, edgeTableNames))
        ; <generate-error-on-duplicates(|ctx, "Duplicate element table name; use an alias to make the element table name unique (table AS alias)")> elementTableNames
 
-       // check for unresolved references from edge tables to vertex tables
-       // we only do so if there are no base graphs
        ; if <?None()> baseGraphs
-         then vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
+         then // check for unresolved references from edge tables to vertex tables
+              // we only do so if there are no base graphs
+              vertexTableReferences := <collect(( ?SourceVertexTable(_, ReferencedVertexTable(Name(_, <id>), _)) +
                                                   ?DestinationVertexTable(_, ReferencedVertexTable(Name(_, <id>), _))
                                                 ); to-identifier-without-origin-info)> edgeTables
             ; unresolvedVertexTableReferences := <diff> (vertexTableReferences, vertexTableNames)
             ; <batch-generate-error(|ctx, "Undefined vertex table")> unresolvedVertexTableReferences
+         else // check for duplicate base graphs
+              baseGraphNames := <?Some(BaseGraphs(<id>)); map(?BaseGraph(<id>, _)); alltd(to-identifier-without-origin-info)> baseGraphs
+             ; <generate-error-on-duplicates(|ctx, "Duplicate base graph reference")> baseGraphNames
          end
 
   to-identifier-without-origin-info = origin-track-forced(?Identifier(localName, _); !localName)

--- a/pgql-tests/error-messages/DDL.spt
+++ b/pgql-tests/error-messages/DDL.spt
@@ -44,7 +44,7 @@ test Duplicate vertex and edge tables [[
 test Duplicate vertex and edge tables [[
 
   CREATE PROPERTY GRAPH MyGraph
-    BASE GRAPHS ( g1 ELEMENT TABLES ( [[person]], [[knows]] ) )
+    BASE GRAPHS ( g1 ELEMENT TABLES ( [[person]], [[knows]], [[post]], [[post]], v1 AS [[v3]], v2 AS [[v3]] ) )
     VERTEX TABLES (
       [[Person]]
     )
@@ -52,7 +52,7 @@ test Duplicate vertex and edge tables [[
       [[knows]] SOURCE Person DESTINATION Person
     )
 
-]] error like "Duplicate element table name; use an alias to make the element table name unique (table AS alias)" at #1, #2, #3, #4
+]] error like "Duplicate element table name; use an alias to make the element table name unique (table AS alias)" at #1, #2, #3, #4, #5, #6, #7, #8
 
 test Missing property name [[
 
@@ -94,3 +94,10 @@ test Missing KEY clause [[
         [[destination employees ( employee_id )]]
     )
 ]] error like "Referenced column list provided but no KEY clause specified" at #1, #2
+
+test Duplicate base graph reference [[
+
+  CREATE PROPERTY GRAPH MyGraph
+    BASE GRAPHS ( [[g1]], [[g1]] )
+
+]] error like "Duplicate base graph reference" at #1, #2


### PR DESCRIPTION
also add/improve checks for: 
 - duplicate base graphs
 - duplicate element tables in base graphs