### PR TITLE
Merge LATERAL and GRAPH_TABLE into outer query when possible

### DIFF
--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/PgqlUtils.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/PgqlUtils.java
@@ -267,23 +267,24 @@ public class PgqlUtils {
   }
 
   protected static String printPgqlString(QueryVariable variable) {
-    if (variable.getVariableType() == VariableType.EXP_AS_VAR) {
-      ExpAsVar expAsVar = (ExpAsVar) variable;
-      if (expAsVar.isAnonymous()) {
-        // e.g. in "SELECT x.prop1 + x.prop2 FROM g MATCH( (n) ) ORDER BY x.prop1 + x.prop2", the ORDER BY expression
-        // "x.prop1 + x.prop2" is a VarRef to the anonymous SELECT expression "x.prop1 + x.prop2"
-        return expAsVar.getExp().toString();
-      }
-    }
-
     return printIdentifier(variable.name, false);
   }
 
   protected static String printPgqlString(ExpAsVar expAsVar) {
-    if (expAsVar.isAnonymous()) {
+    if (expAsVar.getExp().getExpType() == ExpressionType.ALL_PROPERTIES) {
       return expAsVar.getExp().toString();
     } else {
-      return expAsVar.getExp() + " AS " + printIdentifier(expAsVar.getName(), false);
+      String printedExpAsVar = expAsVar.getExp().toString();
+      String printedName = printIdentifier(expAsVar.getName(), false);
+      if (expAsVar.isAnonymous() && printedExpAsVar.equals(printedName)) {
+        return printedExpAsVar; // print e.g. GROUP BY x AS GROUP BY x and not GROUP BY x AS x
+      } else {
+        // here we also convert some anonymous ExpAsVars into non-anonymous ExpAsVars, which is needed because the
+        // original query gets transformed/optimized in various ways and an anonymous ExpAsVar may be referenced in
+        // different contexts than in the original query so that it needs to be deanonymized for the pretty-printed
+        // query to be valid
+        return expAsVar.getExp() + " AS " + printIdentifier(expAsVar.getName(), false);
+      }
     }
   }
 

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/util/ReplaceExpressions.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/util/ReplaceExpressions.java
@@ -191,6 +191,11 @@ public abstract class ReplaceExpressions implements QueryExpressionVisitor {
     replaceInUnaryExpression(aggrArrayAgg);
   }
 
+  @Override
+  public void visit(QueryExpression.Aggregation.AggrJsonArrayagg aggrJsonArrayagg) {
+    replaceInUnaryExpression(aggrJsonArrayagg);
+  }
+
   // Other expressions
 
   @Override

--- a/pgql-spoofax/trans/check.str
+++ b/pgql-spoofax/trans/check.str
@@ -21,7 +21,7 @@ rules // Unresolved/duplicate variables
   nabl-check-disable-duplicate(|uri, ns) = id
 
   nabl-constraint(|ctx):
-    query@NormalizedQuery(_, selectClause, _, _, _, group-by, having, order-by, _, _, _, _, _) -> <fail>
+    query@NormalizedQuery(_, selectClause, _, _, _, group-by, having, order-by, _, _) -> <fail>
     with unresolved-vars := <collect-in-outer-query(?VarRef(<id>))> query
         ; if None() := group-by
           then <batch-generate-error(|ctx, "Unresolved variable")> unresolved-vars
@@ -35,7 +35,7 @@ rules // Unresolved/duplicate variables
           end
 
   nabl-constraint(|ctx):
-    NormalizedQuery(_, selectOrModifyClauseWithAnnos, _, tableExpressionsWithAnnos, _, groupClauseWithAnnos, _, _, _, _, _, _, _) -> <fail>
+    NormalizedQuery(_, selectOrModifyClauseWithAnnos, _, tableExpressionsWithAnnos, _, groupClauseWithAnnos, _, _, _, _) -> <fail>
     with selectOrModifyClause := <strip-annos> selectOrModifyClauseWithAnnos
        ; tableExpressions := <strip-annos> tableExpressionsWithAnnos
        ; groupClause := <strip-annos> groupClauseWithAnnos
@@ -84,7 +84,7 @@ rules // Unresolved/duplicate variables
          end
 
   nabl-constraint(|ctx):
-    query@NormalizedQuery(_, selectOrModifyClause, _, _, _, _, _, _, _, _, _, _, _) -> <fail>
+    query@NormalizedQuery(_, selectOrModifyClause, _, _, _, _, _, _, _, _) -> <fail>
     with group-variables := <collect-in-outer-query(?CommonPathExpression(_, _, _, _, _); get-origin-positions-of-variables); concat> query
        ; aggregations := <get-aggregations> query
        ; varRefs-per-aggregation := <map(origin-track-forced(collect-in-outer-query(?VarRef(_, <id>)); !Some(<id>)))> aggregations
@@ -175,7 +175,7 @@ rules // vertex in WHERE without rounded brackets
 rules
 
   nabl-constraint(|ctx):
-    NormalizedQuery(_, SelectClause(_, SelectList(selectElements)), _, _, _, groupClause, havingClause, orderByClause, _, _, _, _, _) -> <fail>
+    NormalizedQuery(_, SelectClause(_, SelectList(selectElements)), _, _, _, groupClause, havingClause, orderByClause, _, _) -> <fail>
     where
       None() := groupClause
     ; [] := <get-aggregations> selectElements // there are no aggregations in the SELECT
@@ -185,7 +185,7 @@ rules
 
   // if SELECT DISTINCT then ORDER BY expressions may only be repetitions of expressions in SELECT
   nabl-constraint(|ctx):
-    NormalizedQuery(_, SelectClause(Some(Distinct()), SelectList(selectElements)), _, _, _, _, _, Some(OrderByClause(order-by-elems)), _, _, _, _, _) -> <fail>
+    NormalizedQuery(_, SelectClause(Some(Distinct()), SelectList(selectElements)), _, _, _, _, _, Some(OrderByClause(order-by-elems)), _, _) -> <fail>
     with
       select-vars := <map(?ExpAsVar(_, Identifier(<id>, _), _, _)); strip-annos> selectElements
     ; order-by-expressions := <map(?OrderByElem(<id>, _, _)); strip-annos> order-by-elems
@@ -201,7 +201,7 @@ rules
     with <generate-error(|ctx, "SELECT * not allowed in combination with GROUP BY")> e
 
   nabl-constraint(|ctx):
-    NormalizedQuery(_, SelectClause(Star(), e@SelectList([])), _, tableExpressions, _, _, _, _, _, _, _, _, _) -> <fail>
+    NormalizedQuery(_, SelectClause(Star(), e@SelectList([])), _, tableExpressions, _, _, _, _, _, _) -> <fail>
     with if <not(oncetd(?AllProperties(_, _)))> tableExpressions // to allow for parsing and pretty printing when no metadata is available, we only generate the error if no lateral derived table contains an n.* because then we don't know how many elements the SELECT * would have
          then <generate-error(|ctx, "SELECT * not allowed if there are no variables in the graph pattern")> e
          end
@@ -213,26 +213,26 @@ rules
 rules // subqueries
 
   nabl-constraint(|ctx):
-    q@NormalizedQuery(_, _, _, _, _, _, _, _, _, _, _, _, _) -> <fail>
+    q@NormalizedQuery(_, _, _, _, _, _, _, _, _, _) -> <fail>
     with scalarSubqueries := <collect(?Exists(_) + ?DerivedTable(_, _, _) + ?Subquery(_)); remove-all(?Exists(_) + ?DerivedTable(_, _, _))> q
        ; multiColumnScalarSubqueries := <filter(is-multi-column-subquery)> scalarSubqueries
        ; zeroColumnScalarSubqueries := <filter(is-zero-column-subquery)> scalarSubqueries
        ; <batch-generate-error(|ctx, "Scalar subquery is expected to return a single column, but multiple columns were returned")> multiColumnScalarSubqueries
        ; <batch-generate-error(|ctx, "Scalar subquery is expected to return a single column, but zero columns were returned")> zeroColumnScalarSubqueries
 
-  is-multi-column-subquery = ?Subquery(NormalizedQuery(_, SelectClause(_, e@SelectList(selectElements)), _, _, _, _, _, _, _, _, _, _, _))
+  is-multi-column-subquery = ?Subquery(NormalizedQuery(_, SelectClause(_, e@SelectList(selectElements)), _, _, _, _, _, _, _, _))
                            ; where( <gt> (<length> selectElements, 1) ); !e
 
-  is-zero-column-subquery = ?Subquery(NormalizedQuery(_, SelectClause(_, e@SelectList(selectElements)), _, _, _, _, _, _, _, _, _, _, _))
+  is-zero-column-subquery = ?Subquery(NormalizedQuery(_, SelectClause(_, e@SelectList(selectElements)), _, _, _, _, _, _, _, _))
                            ; where( <eq> (<length> selectElements, 0) ); !e
 
   nabl-constraint(|ctx):
-    Subquery(NormalizedQuery(_, t@selectOrUpdateClause, _, _, _, _, _, _, _, _, _, _, _)) -> <fail>
+    Subquery(NormalizedQuery(_, t@selectOrUpdateClause, _, _, _, _, _, _, _, _)) -> <fail>
     where not ( <?SelectClause(_, _)> selectOrUpdateClause )
     with <generate-error(|ctx, "SELECT clause expected here")> t
 
   nabl-constraint(|ctx):
-    t@NormalizedQuery(_, _, _, _, _, _, _, _, _, _, "v1.3", _, _) -> <fail>
+    t@NormalizedQuery(_, _, _, _, _, _, _, _, _, QueryAnnotations(_, "v1.3", _, _, _)) -> <fail>
     with nonPgql13Subqueries := <collect(is-non-pgql13-query)> t
        ; <map(get-select-clause); batch-generate-error(|ctx, "Subquery uses older version of PGQL syntax; please make sure that both inner and outer query use the same PGQL version")> nonPgql13Subqueries
 
@@ -242,14 +242,14 @@ rules // subqueries
     with pgql13Subqueries := <collect(is-pgql13-query)> t
        ; <map(get-select-clause); batch-generate-error(|ctx, "Subquery uses PGQL 1.3 syntax but outer query does not")> pgql13Subqueries
 
-  is-pgql13-query = ?NormalizedQuery(_, _, _, _, _, _, _, _, _, _, "v1.3", _, _)
+  is-pgql13-query = ?NormalizedQuery(_, _, _, _, _, _, _, _, _, QueryAnnotations(_, "v1.3", _, _, _))
 
-  is-non-pgql13-query = ?NormalizedQuery(_, _, _, _, _, _, _, _, _, _, version, _, _); where (!version; not(?"v1.3"))
+  is-non-pgql13-query = ?NormalizedQuery(_, _, _, _, _, _, _, _, _,  QueryAnnotations(_, version, _, _, _)); where (!version; not(?"v1.3"))
 
-  get-select-clause = ?NormalizedQuery(_, <id>, _, _, _, _, _, _, _, _, _, _, _)
+  get-select-clause = ?NormalizedQuery(_, <id>, _, _, _, _, _, _, _, _)
 
   nabl-constraint(|ctx):
-    ScalarSubquery(Subquery(NormalizedQuery(_, SelectClause(_, SelectList([ExpAsVar(ExpressionPlusType(exp, Type(t)), _, _, _)])), _, _, _, _, _, _, _, _, _, _, _))) -> <fail>
+    ScalarSubquery(Subquery(NormalizedQuery(_, SelectClause(_, SelectList([ExpAsVar(ExpressionPlusType(exp, Type(t)), _, _, _)])), _, _, _, _, _, _, _, _))) -> <fail>
     where <?"VERTEX" + ?"EDGE"> t
     with <generate-error(|ctx, "Scalar subquery not allowed to return a vertex or an edge")> exp
 
@@ -379,7 +379,7 @@ rules // literals
     with <generate-error(|ctx, m)> datetime
 
   nabl-constraint(|ctx):
-    t@NormalizedQuery(_, _, _, _, _, _, _, _, _, _, pgqlVersion, _, _) -> <fail>
+    t@NormalizedQuery(_, _, _, _, _, _, _, _, _, QueryAnnotations(_, pgqlVersion, _, _, _)) -> <fail>
     where not ( <?"v1.0" + ?"v1.1"> pgqlVersion )
     with <alltd-in-outer-query(check-illegal-java-escaping(|ctx))> t
 
@@ -461,7 +461,7 @@ rules // IN predicate and CASE expression
 rules // SELECT
 
   nabl-constraint(|ctx):
-    NormalizedQuery(_, t@SelectClause(_, _), _, [], _, _, _, _, _, _, _, _, _) -> <fail>
+    NormalizedQuery(_, t@SelectClause(_, _), _, [], _, _, _, _, _, _) -> <fail>
     with <generate-error(|ctx, "SELECT query without FROM clause not supported")> t
 
 rules // MODIFY
@@ -897,6 +897,6 @@ rules // GRAPH_TABLE
     with <generate-error(|ctx, "GRAPH_TABLE restriction: aggregation does not allow vertex or edge input; use the vertex/edge identifier or a property instead")> exp
 
   nabl-constraint(|ctx):
-    DerivedTable(Some(GraphTable()), Subquery(NormalizedQuery(_, selectClause, _, _, _, CreateOneGroup(), _, _, _, _, _, _, _)), None()) -> <fail>
+    DerivedTable(Some(GraphTable()), Subquery(NormalizedQuery(_, selectClause, _, _, _, CreateOneGroup(), _, _, _, _)), None()) -> <fail>
     with aggregations := <collect(is-aggregate)> selectClause
        ; <batch-generate-error(|ctx, "COLUMNS clause allows only aggregations that access at least one group variable")> aggregations

--- a/pgql-spoofax/trans/common.str
+++ b/pgql-spoofax/trans/common.str
@@ -139,7 +139,7 @@ rules
                                      ; collect-om(?Edge(_, Identifier(<id>, _), _, _, _, _) <+ ?Identifier(<id>, _), conc)
 
   collect-vars-from-table-expression:
-    DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, _, _, _, _, _)), _) -> vars
+    DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, _, _)), _) -> vars
     with vars := <filter(?ExpAsVar(_, Identifier(<id>, _), _, _))> expAsVars
 
   collect-var-def-offsets-from-graph-pattern = ?GraphPattern(vertices, connections, _); !(vertices, connections)
@@ -148,7 +148,7 @@ rules
   collect-var-def-offsets = collect(?Vertex(_, <id>, _) + ?Edge(_, _, _, _, <id>, _) + ?RowsPerMatchVariable(_, <id>, _, _) + ?ExpAsVar(_, _, _, <id>))
 
   collect-offsets-from-table-expression:
-    DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, _, _, _, _, _)), _) -> vars
+    DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, _, _)), _) -> vars
     with vars := <filter(?ExpAsVar(ExpressionPlusType(VarRef(_, <id>), Type("VERTEX")), _, _, _) +
                          ?ExpAsVar(ExpressionPlusType(VarRef(_, <id>), Type("EDGE")), _, _, _))> expAsVars
 

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -30,8 +30,8 @@ rules
 rules
 
   trans-query(|variables, metadata, variable-counter):
-    NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables) ->
-        (NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions''', whereClause', groupBy', having', orderBy', limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables), variables-in-projection)
+    NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, queryAnnotations) ->
+        (NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions''', whereClause', groupBy', having', orderBy', limitOffsets, queryAnnotations), variables-in-projection)
     with variables' := <guarantee-size-two-or-more> variables
 
        // PATH
@@ -206,7 +206,7 @@ rules
     ; map(generate-ExpAsVar(|star))
 
   extract-variables-for-select-star(|star, variable-counter) =
-      ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)
+      ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _)), _)
     ; filter(
         ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
         pull-up-AllProperties(|variable-counter) // no metadata was available to translate the n.* so we pull it up
@@ -223,7 +223,7 @@ rules
 
   replace-all-AllProperties(|variable-counter) = ?GraphPattern(_, _, _)
 
-  replace-all-AllProperties(|variable-counter) = DerivedTable(id, Subquery(NormalizedQuery(id, replace-AllProperties-in-Select(|variable-counter), id, id, id, id, id, id, id, id, id, id, id)), id)
+  replace-all-AllProperties(|variable-counter) = DerivedTable(id, Subquery(NormalizedQuery(id, replace-AllProperties-in-Select(|variable-counter), id, id, id, id, id, id, id, id)), id)
 
   replace-AllProperties-in-Select(|variable-counter) = origin-track-forced(SelectClause(id, SelectList(map(try(replace-AllProperties(|variable-counter))))))
 

--- a/pgql-spoofax/trans/names.nab
+++ b/pgql-spoofax/trans/names.nab
@@ -15,7 +15,7 @@ properties
 
 binding rules // scoping
 
-  NormalizedQuery(_, _, _, _, _, _, _, _, _, _, _, _, _):
+  NormalizedQuery(_, _, _, _, _, _, _, _, _, _):
     scopes Var, CommonPathExpression
 
 binding rules // variable definition

--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -192,7 +192,7 @@ rules
          NormalizedQuery(
               CommonPathExpressions([])
             , SelectClause(
-                None() // no DISTINCT
+                noneOrStarOrDistinct
               , SelectList(expAsVars)
               )
             , graphName
@@ -217,7 +217,8 @@ rules
     , constraints
     , groupBy', having', orderBy', limitOffset
     , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
-    where <map(expAsVar-is-referenced(|(selectClause, groupBy, having, orderBy)))> expAsVars
+    where <not(?Some(Distinct()))> noneOrStarOrDistinct // no DISTINCT
+        ; <map(expAsVar-is-referenced(|(selectClause, groupBy, having, orderBy)))> expAsVars // all projected variables from subquery are referenced by outer query
         ; <not(?[])> expAsVars // the inner query has zero columns which is an error; we won't pull up this subquery
     with selectClause' := <replace-varRefs-with-expressions(|expAsVars)> selectClause
        ; groupBy' := <replace-varRefs-with-expressions(|expAsVars)> groupBy

--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -15,6 +15,7 @@ rules
                   ; innermost(inPredicate-to-non-equality-constraints(|metadata) <+ norm-inPredicate)
                   ; alltd(norm-matchnum)
                   ; AstPlusMetadata(push-down-predicates(|[]), id))
+                  ; bottomup(try(pull-lateral-query-up))
 
 rules
 
@@ -181,3 +182,54 @@ rules
   dereference-vertex-correlation(|vertexCorrelations):
     VarRef(identifier, v) -> VarRef(identifier, v')
     where <oncetd(?Vertex(_, v, Correlation(ExpressionPlusType(VarRef(_, v'), _))))> vertexCorrelations
+
+rules
+
+  pull-lateral-query-up:
+    NormalizedQuery(commonPathExpressions, selectClause, graphName
+    , [DerivedTable(lateralOrGraphTable,
+        Subquery(
+         NormalizedQuery(
+              CommonPathExpressions([])
+            , SelectClause(
+                None() // DISTINCT
+              , SelectList(expAsVars)
+              )
+            , graphName
+            , tableExpressions
+            , Constraints(inner-constraints) // non-pushed down constraints
+            , None() // GROUP BY
+            , None() // HAVING
+            , None() // ORDER BY
+            , LimitOffsetClauses(None(), None())
+            , [] // error messages
+            , pgqlVersion, _, _)
+            )
+        , None()
+        )
+      ]
+    , Constraints(outer-constraints)
+    , groupBy, having, orderBy, limitOffset
+    , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
+    ->
+    NormalizedQuery(commonPathExpressions, selectClause', graphName
+    , tableExpressions
+    , Constraints(<conc> (inner-constraints, outer-constraints'))
+    , groupBy', having', orderBy', limitOffset
+    , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
+    where <map(expAsVar-is-referenced(|(selectClause, outer-constraints, groupBy, having, orderBy)))> expAsVars
+    with selectClause' := <replace-varRefs-with-expressions(|expAsVars)> selectClause
+       ; outer-constraints' := <replace-varRefs-with-expressions(|expAsVars)> outer-constraints
+       ; groupBy' := <replace-varRefs-with-expressions(|expAsVars)> groupBy
+       ; having' := <replace-varRefs-with-expressions(|expAsVars)> having
+       ; orderBy' := <replace-varRefs-with-expressions(|expAsVars)> orderBy
+
+  expAsVar-is-referenced(|outer-query-parts):
+    ExpAsVar(_, _, _, originOffset) -> <id>
+    where <oncetd(?VarRef(_, originOffset))> outer-query-parts
+
+  replace-varRefs-with-expressions(|expAsVars) = alltd(replace-varRef-with-expression(|expAsVars))
+
+  replace-varRef-with-expression(|expAsVars):
+    VarRef(_, originOffset) -> exp
+    where <collect-one(?ExpAsVar(exp, _, _, originOffset))> expAsVars

--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -72,7 +72,7 @@ rules
 rules
 
   push-down-predicates(|variablesOuterQuery):
-    NormalizedQuery(commonPathExpressions, selectOrModifyClause, optionalGraphName, tableExpressions, Constraints(expressions), groupBy, having, orderBy, limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables)
+    NormalizedQuery(commonPathExpressions, selectOrModifyClause, optionalGraphName, tableExpressions, Constraints(expressions), groupBy, having, orderBy, limitOffsets, queryAnnotations)
       -> NormalizedQuery( <push-down-predicates-for-commonPathExpressions(|variablesOuterQuery)> commonPathExpressions
                         , <alltd(push-down-predicates(|variablesOuterQuery''))> selectOrModifyClause
                         , optionalGraphName
@@ -81,12 +81,12 @@ rules
                         , <alltd(push-down-predicates(|variablesOuterQuery'))> groupBy
                         , <alltd(push-down-predicates(|variablesOuterQuery'''))> having
                         , <alltd(push-down-predicates(|variablesOuterQuery'''))> orderBy
-                        , limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables)
+                        , limitOffsets, queryAnnotations)
     with expressions' := <map(conjunction-to-list); concat> expressions
 
          // references to vertices that correlate with vertices in SELECT of prior LATERAL subquery are replaced with references to those prior vertices
          // this allows for pushing down even more predicates
-       ; vertices-projected-by-laterals := <filter(?DerivedTable(Some(Lateral()), Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _, _, _, _)), _)); flatten-list; filter(?ExpAsVar(_, _, _, <id>))> tableExpressions
+       ; vertices-projected-by-laterals := <filter(?DerivedTable(Some(Lateral()), Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _)), _)); flatten-list; filter(?ExpAsVar(_, _, _, <id>))> tableExpressions
        ; lateralVertexCorrelations := <collect(vertex-correlates-to-vertex-projected-by-lateral-subquery(|vertices-projected-by-laterals))> tableExpressions
        ; expressions'' := <alltd(dereference-vertex-correlation(|lateralVertexCorrelations))> expressions'
 
@@ -118,7 +118,7 @@ rules
 
   try-push-down-predicates(|variablesOuterQuery):
     (
-      t@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, constraints@Constraints(subquery-constraints), groupByClause, havingClause, _, limitOffsetClauses, _, _, _, _)), correlation)
+      t@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, constraints@Constraints(subquery-constraints), groupByClause, havingClause, _, limitOffsetClauses, _)), correlation)
     , (remaining-expressions-plus-varRefs, tableExpressions, allVariablesExceptFromOuterQuery)
     ) -> (remaining-expressions-plus-varRefs'', tableExpressions', allVariablesExceptFromOuterQuery')
     where <?LimitOffsetClauses(None(), None())> limitOffsetClauses // if there is a LIMIT (or FETCH FIRST) and/or an OFFSET then we cannot push down any predicate without altering the result, in particular if the subquery has an ORDER BY
@@ -138,14 +138,14 @@ rules
             ; havingClause' := havingClause
          end
        ; visible-variables-to-lateral-query := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery)
-       ; normalizedQuery' := <NormalizedQuery(id, id, id, id, !constraints', id, !havingClause', id, id, id, id, id, id); push-down-predicates(|visible-variables-to-lateral-query)> normalizedQuery
+       ; normalizedQuery' := <NormalizedQuery(id, id, id, id, !constraints', id, !havingClause', id, id, id); push-down-predicates(|visible-variables-to-lateral-query)> normalizedQuery
        ; derivedTable := <origin-track-forced(!DerivedTable(lateral, Subquery(normalizedQuery'), correlation))> t
        ; tableExpressions' := <conc> (tableExpressions, [derivedTable])
        ; allVariablesExceptFromOuterQuery' := <conc; make-set> (allVariablesExceptFromOuterQuery, new-variables)
 
   try-push-down-predicates(|variablesOuterQuery):
     (
-      derivedTable@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, limitOffsetClauses, _, _, _, _)), _)
+      derivedTable@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, limitOffsetClauses, _)), _)
     , (remaining-expressions-plus-varRefs, tableExpressions, allVariablesExceptFromOuterQuery)
     ) -> (remaining-expressions-plus-varRefs, tableExpressions', allVariablesExceptFromOuterQuery')
     where <not(?LimitOffsetClauses(None(), None()))> limitOffsetClauses // if there is a LIMIT (or FETCH FIRST) and/or an OFFSET then we cannot push down any predicate without altering the result, in particular if the subquery has an ORDER BY
@@ -202,21 +202,26 @@ rules
             , None() // no HAVING
             , None() // no ORDER BY
             , LimitOffsetClauses(None(), None()) //no LIMIT / FETCH FIRST or OFFSET
-            , [] // o errors
-            , pgqlVersion, _, _) // pgql version of inner query should be the same as outer query (we're using the same variable name below)
+            , QueryAnnotations(
+                [] // no errors
+              , pgqlVersion // pgql version of inner query should be the same as outer query (we're using the same variable name below)
+              , _
+              , _
+              , graphTable) // if subquery is a GRAPH_TABLE we want to preserve that info as we need to apply certain checks for GRAPH_TABLE queries
+              )
             )
         , None()
         )
       ]
     , Constraints([]) // outer query will not have any non-pushed down constraints if subquery has no LIMIT / FETCH FIRST / OFFSET, like is asserted above already
     , groupBy, having, orderBy, limitOffset
-    , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
+    , queryAnnotations)
     ->
     NormalizedQuery(commonPathExpressions, selectClause', graphName
     , tableExpressions
     , constraints
     , groupBy', having', orderBy', limitOffset
-    , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
+    , queryAnnotations')
     where <not(?Some(Distinct()))> noneOrStarOrDistinct // no DISTINCT
         ; <map(expAsVar-is-referenced(|(selectClause, groupBy, having, orderBy)))> expAsVars // all projected variables from subquery are referenced by outer query
         ; <not(?[])> expAsVars // the inner query has zero columns which is an error; we won't pull up this subquery
@@ -224,6 +229,7 @@ rules
        ; groupBy' := <replace-varRefs-with-expressions(|expAsVars)> groupBy
        ; having' := <replace-varRefs-with-expressions(|expAsVars)> having
        ; orderBy' := <replace-varRefs-with-expressions(|expAsVars)> orderBy
+       ; queryAnnotations' := <QueryAnnotations(id, id, id, id, !graphTable)> queryAnnotations
 
   expAsVar-is-referenced(|outer-query-parts):
     ExpAsVar(_, _, _, originOffset) -> <id>

--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -192,34 +192,34 @@ rules
          NormalizedQuery(
               CommonPathExpressions([])
             , SelectClause(
-                None() // DISTINCT
+                None() // no DISTINCT
               , SelectList(expAsVars)
               )
             , graphName
             , tableExpressions
-            , Constraints(inner-constraints) // non-pushed down constraints
-            , None() // GROUP BY
-            , None() // HAVING
-            , None() // ORDER BY
-            , LimitOffsetClauses(None(), None())
-            , [] // error messages
-            , pgqlVersion, _, _)
+            , constraints // non-pushed-down constraints
+            , None() // no GROUP BY
+            , None() // no HAVING
+            , None() // no ORDER BY
+            , LimitOffsetClauses(None(), None()) //no LIMIT / FETCH FIRST or OFFSET
+            , [] // o errors
+            , pgqlVersion, _, _) // pgql version of inner query should be the same as outer query (we're using the same variable name below)
             )
         , None()
         )
       ]
-    , Constraints(outer-constraints)
+    , Constraints([]) // outer query will not have any non-pushed down constraints if subquery has no LIMIT / FETCH FIRST / OFFSET, like is asserted above already
     , groupBy, having, orderBy, limitOffset
     , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
     ->
     NormalizedQuery(commonPathExpressions, selectClause', graphName
     , tableExpressions
-    , Constraints(<conc> (inner-constraints, outer-constraints'))
+    , constraints
     , groupBy', having', orderBy', limitOffset
     , errorMessages, pgqlVersion, bindVariableCount, selectingAllProperties)
-    where <map(expAsVar-is-referenced(|(selectClause, outer-constraints, groupBy, having, orderBy)))> expAsVars
+    where <map(expAsVar-is-referenced(|(selectClause, groupBy, having, orderBy)))> expAsVars
+        ; <not(?[])> expAsVars // the inner query has zero columns which is an error; we won't pull up this subquery
     with selectClause' := <replace-varRefs-with-expressions(|expAsVars)> selectClause
-       ; outer-constraints' := <replace-varRefs-with-expressions(|expAsVars)> outer-constraints
        ; groupBy' := <replace-varRefs-with-expressions(|expAsVars)> groupBy
        ; having' := <replace-varRefs-with-expressions(|expAsVars)> having
        ; orderBy' := <replace-varRefs-with-expressions(|expAsVars)> orderBy

--- a/pgql-spoofax/trans/normalize.str
+++ b/pgql-spoofax/trans/normalize.str
@@ -300,12 +300,12 @@ rules
   // In PGQL 1.1 and PGQL 1.2, subqueries would inherit the graph name from the outer query.
   // This is no longer the case in PGQL 1.3+, where graph names in subqueries need to be respecified.
   copy-graph-name-to-queries-without-one:
-    ast@NormalizedQuery(_, _, _, _, _, _, _, _, _, _, "v1.1", _, _) -> ast'
-    where <oncetd(?NormalizedQuery(_, _, Some(graphName), _, _, _, _, _, _, _, _, _, _))> ast
+    ast@NormalizedQuery(_, _, _, _, _, _, _, _, _, QueryAnnotations(_, "v1.1", _, _, _)) -> ast'
+    where <oncetd(?NormalizedQuery(_, _, Some(graphName), _, _, _, _, _, _, QueryAnnotations(_, _, _, _, _)))> ast
     with ast' := <innermost(copy-graph-name-to-query-without-one(|graphName))> ast
 
   copy-graph-name-to-query-without-one(|graphName):
-    NormalizedQuery(a, b, None(), c, d, e, f, g, h, i, j, k, l) -> NormalizedQuery(a, b, Some(graphName), c, d, e, f, g, h, i, j, k, l)
+    NormalizedQuery(a, b, None(), c, d, e, f, g, h, i) -> NormalizedQuery(a, b, Some(graphName), c, d, e, f, g, h, i)
 
   norm-BindVariable(|c) = ?BindVariable(); !BindVariable(<next-counter> c)
 
@@ -800,7 +800,7 @@ rules
 
   norm-query(|error-messages, version, variable-counter, bindVariableCount):
     t@(commonPathExpressions, selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupByClause, havingClause, orderByClause, limitOffsets) ->
-        NormalizedQuery(commonPathExpressions', selectOrModifyClause', optionalGraphName, tableExpressions, whereClause, groupByClause', havingClause, orderByElems, limitOffsets', error-messages, version, bindVariableCount, selectingAllProperties)
+        NormalizedQuery(commonPathExpressions', selectOrModifyClause', optionalGraphName, tableExpressions, whereClause, groupByClause', havingClause, orderByElems, limitOffsets', QueryAnnotations(error-messages, version, bindVariableCount, selectingAllProperties, graphTable))
     with
       commonPathExpressions' := <map(norm-common-path-expression(|variable-counter)); !CommonPathExpressions(<id>)> commonPathExpressions;
 
@@ -814,7 +814,8 @@ rules
 
       limitOffsets' := <norm-limitOffsets> limitOffsets;
 
-      selectingAllProperties := <oncetd(?AllProperties(_, _)); !True() <+ !False()> t
+      selectingAllProperties := <oncetd(?AllProperties(_, _)); !True() <+ !False()> t;
+      graphTable := None()
 
   norm-SelectList(|version):
     t1@SelectClause(distinct, t2@SelectList(selectElements)) -> result
@@ -862,10 +863,7 @@ rules // GRAPH_TABLE
           , having
           , orderBy
           , limitOffset
-          , errorMessages
-          , pgqlVersion
-          , bindVariableCount
-          , selectingAllProperties
+          , QueryAnnotations(errorMessages , pgqlVersion , bindVariableCount, selectingAllProperties, Some(GraphTable()))
           )
         )
       , correlation)

--- a/pgql-spoofax/trans/normalized-signatures.str
+++ b/pgql-spoofax/trans/normalized-signatures.str
@@ -18,7 +18,8 @@ signature constructors // for type checking (see trans/types.ts)
 signature constructors // for the normalized AST (see trans/normalize.str)
 
   AstPlusMetadata       : Ast * Metadata -> AstPlusMetadata
-  NormalizedQuery       : CommonPathExpressions * Vars * FromClause * TableExpressions * WhereClause * GroupByClause * HavingClause * List(OrderByElem) * LimitOffsetClauses * List(ErrorMessage) * PgqlVersion * BindVariableCount * SelectingAllProperties -> NormalizedQuery
+  NormalizedQuery       : CommonPathExpressions * Vars * FromClause * TableExpressions * WhereClause * GroupByClause * HavingClause * List(OrderByElem) * LimitOffsetClauses * QueryAnnotations -> NormalizedQuery
+  QueryAnnotations      : List(ErrorMessage) * PgqlVersion * BindVariableCount * SelectingAllProperties * Option(GraphTable) -> QueryAnnotations
   PgqlVersion           : STRING
   GraphName             : LocalOrSchemaQualifiedName -> GraphName
   CommonPathExpressions : List(CommonPathExpression) -> CommonPathExpressions

--- a/pgql-spoofax/trans/type-analysis.str
+++ b/pgql-spoofax/trans/type-analysis.str
@@ -20,8 +20,8 @@ rules
             ; ?(<id>, _); !AstPlusMetadata(<id>, metadata)
 
   add-types-to-query(|metadata, variablesPlusTypes, constraints):
-      NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables) ->
-        ( NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions', whereClause', groupBy', having', orderBy', limitOffsets, error-messages, version, bindVariableCount, selectingAllVariables)
+      NormalizedQuery(CommonPathExpressions(pathExpressions), selectOrModifyClause, optionalGraphName, tableExpressions, whereClause, groupBy, having, orderBy, limitOffsets, queryAnnotations) ->
+        ( NormalizedQuery(CommonPathExpressions(pathExpressions'), selectOrModifyClause', optionalGraphName, tableExpressions', whereClause', groupBy', having', orderBy', limitOffsets, queryAnnotations)
         , variablesPlusTypes''')
     with // PATH
          pathExpressions' := <map(add-types-to-path-expression(|metadata))> pathExpressions
@@ -72,7 +72,7 @@ rules
        ; subquery' := <origin-track-forced(!Subquery(normalizedQuery'))> subquery
        ; derivedTable' := <origin-track-forced(!DerivedTable(lateral, subquery', correlation))> derivedTable
        ; result' := <conc> (result, [derivedTable'])
-       ; if <?NormalizedQuery(_, SelectClause(_, SelectList(selectElements)), _, _, _, _, _, _, _, _, _, _, _)> normalizedQuery'
+       ; if <?NormalizedQuery(_, SelectClause(_, SelectList(selectElements)), _, _, _, _, _, _, _, _)> normalizedQuery'
          then variablesPlusTypes'' := <map(expAsVar-to-variablePlusType(|variablesPlusTypes'))> selectElements
             ; variablesPlusTypes''' := <conc> (variablesPlusTypes, variablesPlusTypes'')
          else variablesPlusTypes''' := variablesPlusTypes
@@ -242,7 +242,7 @@ rules // subqueries
   add-types-to-subquery(|metadata, variablesPlusTypes, constraints):
     query -> (query', type)
     with (query', _) := <add-types-to-query(|metadata, variablesPlusTypes, constraints)> query
-       ; if <?NormalizedQuery(_, SelectClause(_, SelectList([ExpAsVar(ExpressionPlusType(_, Type(t)), _, _, _)])), _, _, _, _, _, _, _, _, _, _, _)> query'
+       ; if <?NormalizedQuery(_, SelectClause(_, SelectList([ExpAsVar(ExpressionPlusType(_, Type(t)), _, _, _)])), _, _, _, _, _, _, _, _)> query'
          then type := Type(t)
          else type := UnknownType()
          end

--- a/pgql-tests/error-messages/graph_table.spt
+++ b/pgql-tests/error-messages/graph_table.spt
@@ -109,12 +109,13 @@ test Restriction: LIMIT outsie GRAPH_TABLE [[
 
 test Restriction: projecting vertex/edge objects [[
 
-  SELECT *
+  SELECT [[*]]
   FROM GRAPH_TABLE ( g
          MATCH (n) -[e]-> (m)
-         COLUMNS ( [[n,]] [[e,]] [[m )]] )
+         COLUMNS ( n, e, m )
+       )
 
-]] error like "GRAPH_TABLE restriction: cannot project vertex or edge objects" at #1, #2, #3
+]] error like "GRAPH_TABLE restriction: cannot project vertex or edge objects" at #1
 
 test Restriction: SHORTEST [[
 


### PR DESCRIPTION
pgql version 2.0.4.1

For example, queries like:

```
SELECT *
FROM GRAPH_TABLE ( LdbcGraph MATCH (n) COLUMNS (n.*) )
FETCH FIRST 10 ROWS ONLY
```

are now translated into:

```
SELECT n.*
FROM MATCH (n) ON LdbcGraph
FETCH FIRST 10 ROWS ONLY
```