### PR TITLE
Fix error when doing v.* or e.* for vertices/edges projected from GROUP BY or LATERAL

### DIFF
--- a/pgql-lang/src/test/java/oracle/pgql/lang/MetadataTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/MetadataTest.java
@@ -1099,4 +1099,30 @@ public class MetadataTest extends AbstractPgqlTest {
     assertEquals("typeConflictProp", expAsVars.get(2).getName());
     assertEquals("typeConflictProp", expAsVars.get(2).getNameOriginText());
   }
+
+  @Test
+  public void testSelectAllPropertiesAfterVariableRenaming() throws Exception {
+    isValid("SELECT n.* FROM MATCH (n:Account) ON financialNetwork GROUP BY n");
+    isValid("SELECT m.* FROM MATCH (n:Account) ON financialNetwork GROUP BY n AS m");
+    isValid("SELECT n.* FROM LATERAL ( SELECT n FROM MATCH (n:account) ON financialNetwork )");
+    isValid("SELECT m.* FROM LATERAL ( SELECT n AS m FROM MATCH (n:account) ON financialNetwork )");
+    isValid(
+        "SELECT p.* FROM LATERAL ( SELECT m AS o FROM MATCH (n:account) ON financialNetwork GROUP BY n AS m ) GROUP BY o AS p");
+    isValid(
+        "SELECT o.* FROM LATERAL ( SELECT m AS o FROM LATERAL ( SELECT n AS m FROM MATCH (n:account) ON financialNetwork LIMIT 1 ) LIMIT 1 )");
+
+    // now test the same queries but for edges
+    isValid("SELECT n.* FROM MATCH () -[n:transaction]-> () ON financialNetwork GROUP BY n");
+    isValid("SELECT m.* FROM MATCH () -[n:transaction]-> () ON financialNetwork GROUP BY n AS m");
+    isValid("SELECT n.* FROM LATERAL ( SELECT n FROM MATCH () -[n:transaction]-> () ON financialNetwork )");
+    isValid("SELECT m.* FROM LATERAL ( SELECT n AS m FROM MATCH () -[n:transaction]-> () ON financialNetwork )");
+    isValid(
+        "SELECT p.* FROM LATERAL ( SELECT m AS o FROM MATCH () -[n:transaction]-> () ON financialNetwork GROUP BY n AS m ) GROUP BY o AS p");
+    isValid(
+        "SELECT o.* FROM LATERAL ( SELECT m AS o FROM LATERAL ( SELECT n AS m FROM MATCH () -[n:transaction]-> () ON financialNetwork LIMIT 1 ) LIMIT 1 )");
+  }
+
+  private void isValid(String query) throws Exception {
+    assertTrue(parse(query).isQueryValid());
+  }
 }

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -56,7 +56,7 @@ rules
 
        // SELECT / INSERT / UPDATE / DELETE
        ; if <?SelectClause(_, _)> selectOrModifyClause
-         then (selectOrModifyClause', variables'''', tableExpressions'') := <resolve-select-clause(|variables''', metadata, variable-counter, valueExpression', tableExpressions', groupByExps)> selectOrModifyClause
+         then (selectOrModifyClause', variables'''', tableExpressions'') := <resolve-select-clause(|variables''', metadata, variable-counter, valueExpression', tableExpressions', groupByExps, groupBy')> selectOrModifyClause
          else selectOrModifyClause' := <resolve-modify-clause(|variables''', metadata, variable-counter)> selectOrModifyClause
             ; variables'''' := variables'''
             ; tableExpressions'' := tableExpressions'
@@ -172,22 +172,22 @@ rules
     with vars' := []
        ; variables' := [vars'|variables]
 
-  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps):
+  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps, groupBy):
     t@SelectClause(distinct, t2@SelectList(selectElements)) -> (selectClause', variables', tableExpressions)
     with varsInCurrentScope := <Hd> variables
-       ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression))> (selectElements, ([], varsInCurrentScope))
+       ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression, tableExpressions, groupBy))> (selectElements, ([], varsInCurrentScope))
        ; selectElements'' := <origin-track-forced(!SelectList(selectElements'))> t2
        ; variables' := [vars'|<Tl> variables]
        ; selectClause' := <origin-track-forced(!SelectClause(distinct, selectElements''))> t
 
-  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps):
+  resolve-select-clause(|variables, metadata, variable-counter, valueExpression, tableExpressions, group-exps, groupBy):
     t@SelectClause(distinct, star@Star()) -> (selectClause', variables', tableExpressions')
     with if [] := group-exps
          then variable-counter-copy := <new-counter>
             ; <set-counter> (variable-counter-copy, <get-counter> variable-counter) // create a copy of the variable counter as we will use one for references and one for definitions
             ; selectElements := <map(extract-variables-for-select-star(|star, variable-counter)); concat; make-set> tableExpressions
             ; varsInCurrentScope := <Hd> variables
-            ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression))> (selectElements, ([], varsInCurrentScope))
+            ; (selectElements', vars') := <foldl(resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression, tableExpressions, groupBy))> (selectElements, ([], varsInCurrentScope))
             ; variables' := [vars'|<Tl> variables]
             ; star' := star
             ; tableExpressions' := <map(replace-all-AllProperties(|variable-counter-copy))> tableExpressions // replace n.* in LATERAL or GRAPH_TABLE subqueries with a projection of n as we've pulled it up at this point
@@ -290,7 +290,7 @@ rules
     (exp1, exp2) -> <id>
     where <not(eq)> (exp1, exp2)
 
-  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression, tableExpressions, groupBy):
     (t@ExpAsVar(exp, iden@Identifier(v, _), anonymous), (result, vars)) -> (result', vars')
     with exp' := <resolve-var-refs(|variables, metadata, variable-counter)> exp
        ; originOffset := <origin-offset> v
@@ -305,12 +305,12 @@ rules
        ; result' := <conc> (result, [expAsVar'])
 
   // expression was defined in GROUP BY and doesn't need to be resolved again
-  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression, tableExpressions, groupBy):
      (expAsVar@ExpAsVar(_, _, _, originOffset), (result, vars)) -> (result', vars')
      with vars' := vars // it was already added during GROUP BY analysis
         ; result' := <conc> (result, [expAsVar])
 
-  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression):
+  resolve-exp-as-var-in-select(|variables, metadata, variable-counter, valueExpression, tableExpressions, groupBy):
     (t@AllProperties(varRef, columnNamePrefix), (result, vars)) -> (result', vars')
     with varRef' := <try(resolve-var-ref(|variables, metadata, variable-counter))> varRef
        ; if <?VarRef(v)> varRef'
@@ -324,7 +324,7 @@ rules
             ; if <?None()> allLabels
               then selectElems := <resolve-var-refs(|variables, metadata, variable-counter)> [t] // no label metadata is provided so we don't process the n.* other than resolve variable n
                  ; vars' := vars
-              else originOffset := <?VarRef(_, <id>) <+ !None()> varRef'
+              else originOffset := <get-base-variable(|tableExpressions, groupBy)> varRef'
                  ; labelExpression := <filter(simplify-label-expression(|originOffset)); (?[]; !All() <+ to-label-conjunction)> valueExpression
                  ; allLabelNames := <(?Type("VERTEX"); get-vertex-labels(|metadata) + ?Type("EDGE"); get-edge-labels(|metadata)); try(?None(); ![])> elementType
                  ; labelReferences := <get-labels-from-label-expression(|allLabelNames)> labelExpression
@@ -336,6 +336,16 @@ rules
               end
          end
        ; result' := <conc> (result, selectElems)
+
+  get-base-variable(|tableExpressions, groupBy):
+    VarRef(_, originOffset) -> originOffset'
+    with if <collect-one(?Vertex(_, originOffset, _) + ?Edge(_, _, _, _, originOffset, _))> (tableExpressions, groupBy)
+         then originOffset' := originOffset
+         else varRef := <collect-one(?ExpAsVar(<id>, _, _, originOffset))> (tableExpressions, groupBy)
+            ; originOffset' := <get-base-variable(|tableExpressions, groupBy)> varRef
+         end
+
+  get-base-variable(|tableExpressions, groupBy) = ?VarRef(_); !None() // unresolved reference
 
   has-label-metadata = fetch-elem(?VertexLabels(_))
 


### PR DESCRIPTION
These queries would previously give errors like:


```
	select n.* from match (n:account) group by n
	       ^^^^
	Property does not exist for any of the labels
```


```
 	SELECT n.* from lateral ( SELECT n from match (n:account) )
 	       ^^^^
  	Property does not exist for any of the labels
```