### PR TITLE
Remove some deprecated syntax and fix two bugs

### DIFF
--- a/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
@@ -39,6 +39,7 @@ import oracle.pgql.lang.ir.QueryExpression.Constant.ConstString;
 import oracle.pgql.lang.ir.QueryExpression.ExpressionType;
 import oracle.pgql.lang.ir.QueryExpression.VarRef;
 import oracle.pgql.lang.ir.QueryPath;
+import oracle.pgql.lang.ir.QueryType;
 import oracle.pgql.lang.ir.QueryVariable;
 import oracle.pgql.lang.ir.QueryVariable.VariableType;
 import oracle.pgql.lang.ir.QueryVertex;
@@ -232,9 +233,13 @@ public class SpoofaxAstToGraphQuery {
           break;
         case "DerivedTable":
           boolean lateral = isSome(tableExpressionT.getSubterm(POS_DERIVED_TABLE_LATERAL));
-          SelectQuery query = (SelectQuery) translate(
+          GraphQuery query = translate(
               tableExpressionT.getSubterm(POS_DERIVED_TABLE_SUBQUERY).getSubterm(POS_SUBQUERY_QUERY), ctx);
-          DerivedTable derivedTable = new DerivedTable(query, lateral);
+          if (query.getQueryType() == QueryType.MODIFY) {
+            break; // INSERT/UPDATE/DELETE not supported in LATERAL subquery; simply ignore it here
+          }
+
+          DerivedTable derivedTable = new DerivedTable((SelectQuery) query, lateral);
           tableExpressions.add(derivedTable);
           break;
         default:

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -459,4 +459,10 @@ public class BugFixTest extends AbstractPgqlTest {
         "  )");
     assertTrue(result.isQueryValid());
   }
+
+  @Test
+  public void illegalQueryShouldNotCrashParser() throws Exception {
+    PgqlResult result = pgql.parse("SELECT * FROM MATCH (v:STUDENT), DELETE (w) FROM MATCH (w)");
+    assertNotNull(result.getErrorMessages());
+  }
 }

--- a/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/BugFixTest.java
@@ -462,7 +462,7 @@ public class BugFixTest extends AbstractPgqlTest {
 
   @Test
   public void illegalQueryShouldNotCrashParser() throws Exception {
-    PgqlResult result = pgql.parse("SELECT * FROM MATCH (v:STUDENT), DELETE (w) FROM MATCH (w)");
+    PgqlResult result = pgql.parse("SELECT * FROM MATCH (v:STUDENT), LATERAL ( DELETE (w) FROM MATCH (w) )");
     assertNotNull(result.getErrorMessages());
   }
 }

--- a/pgql-spoofax/syntax/Legacy.sdf3
+++ b/pgql-spoofax/syntax/Legacy.sdf3
@@ -60,8 +60,6 @@ context-free syntax // GraphPattern.sdf3 for PGQL 1.0
 
   Legacy10PatternElem.Constraint = Exp {avoid} // see Expressions.sdf3. Note: 'avoid' disambiguates 'select * where (X.p1)' ('(X.p1)' can be a Constraint or a Vertex)
 
-  Vertex.VertexWithoutBrackets = <<REGULAR-IDENTIFIER>> // deprecated
-
   Legacy10Ids.Ids = <@<AltLit>>
   Legacy10WithInlinedConstraints.InlinedConstraint = < with <{Legacy10InlinedExp ", "}+>> {case-insensitive}
   AltLit.Or              = <<AltLit>|<AltLit>> {left}

--- a/pgql-spoofax/trans/common.str
+++ b/pgql-spoofax/trans/common.str
@@ -141,8 +141,11 @@ rules
                                      ; collect-om(?Edge(_, Identifier(<id>, _), _, _, _, _) <+ ?Identifier(<id>, _), conc)
 
   collect-vars-from-table-expression:
-    DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, _, _, _, _, _, _)), _) -> vars
-    with vars := <filter(?ExpAsVar(_, Identifier(<id>, _), _, _))> expAsVars
+    DerivedTable(_, Subquery(NormalizedQuery(_, selectOrModifyClause, _, _, _, _, _, _, _, _)), _) -> vars
+    with if <?SelectClause(_, SelectList(expAsVars))> selectOrModifyClause
+         then vars := <filter(?ExpAsVar(_, Identifier(<id>, _), _, _))> expAsVars
+         else vars := [] // will generate an error elsewhere since INSERT/UPDATE/DELETE inside LATERAL is not allowed
+         end
 
   collect-var-def-offsets-from-graph-pattern = ?GraphPattern(vertices, connections, _); !(vertices, connections)
                                              ; collect-var-def-offsets

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -343,7 +343,7 @@ rules
 
   get-base-variable(|tableExpressions, groupBy):
     VarRef(_, originOffset) -> originOffset'
-    with if <collect-one(?Vertex(_, originOffset, _) + ?Edge(_, _, _, _, originOffset, _))> (tableExpressions, groupBy)
+    with if <collect-one(?Vertex(_, originOffset, _) + ?Edge(_, _, _, _, originOffset, _) + ?RowsPerMatchVariable(_, originOffset, _, _))> (tableExpressions, groupBy)
          then originOffset' := originOffset
          else varRef := <collect-one(?ExpAsVar(<id>, _, _, originOffset))> (tableExpressions, groupBy)
             ; originOffset' := <get-base-variable(|tableExpressions, groupBy)> varRef

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -227,6 +227,8 @@ rules
 
   replace-AllProperties-in-Select(|variable-counter) = origin-track-forced(SelectClause(id, SelectList(map(try(replace-AllProperties(|variable-counter))))))
 
+  replace-AllProperties-in-Select(|variable-counter) = ?ModifyClause(_) // INSERT/UPDATE/DELETE in LATERAL not supported; we'll generate an error elsewhere
+
   replace-AllProperties(|variable-counter):
     t@AllProperties(varRef, prefix) -> result
     with name := <unique-name(|variable-counter, t)>

--- a/pgql-spoofax/trans/name-analysis.str
+++ b/pgql-spoofax/trans/name-analysis.str
@@ -205,12 +205,14 @@ rules
     ; filter(is-anonymous-variable)
     ; map(generate-ExpAsVar(|star))
 
-  extract-variables-for-select-star(|star, variable-counter) =
-      ?DerivedTable(_, Subquery(NormalizedQuery(_, SelectClause(_, SelectList(<id>)), _, _, _, _, _, _, _, _)), _)
-    ; filter(
-        ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
-        pull-up-AllProperties(|variable-counter) // no metadata was available to translate the n.* so we pull it up
-      )
+  extract-variables-for-select-star(|star, variable-counter):
+    DerivedTable(_, Subquery(NormalizedQuery(_, selectOrModifyClause, _, _, _, _, _, _, _, _)), _) -> vars
+    with if <?SelectClause(_, SelectList(selectElems))> selectOrModifyClause
+         then vars := <filter(  ?ExpAsVar(_, <id>, _, _); is-anonymous-variable; generate-ExpAsVar(|star) +
+                                pull-up-AllProperties(|variable-counter) // no metadata was available to translate the n.* so we pull it up
+                             )> selectElems
+         else vars := [] // for INSERT/UPDATE/DELETE we return an empty list and will generate an error elsewhere (not allowed as subquery)
+         end
 
   is-anonymous-variable = Identifier(is-string; not(is-substring(GENERATED)), id)
 

--- a/pgql-spoofax/trans/normalize-after.str
+++ b/pgql-spoofax/trans/normalize-after.str
@@ -118,30 +118,36 @@ rules
 
   try-push-down-predicates(|variablesOuterQuery):
     (
-      t@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, SelectClause(_, SelectList(expAsVars)), _, _, constraints@Constraints(subquery-constraints), groupByClause, havingClause, _, limitOffsetClauses, _)), correlation)
+      t@DerivedTable(lateral, Subquery(normalizedQuery@NormalizedQuery(_, selectOrModifyClause, _, _, constraints@Constraints(subquery-constraints), groupByClause, havingClause, _, limitOffsetClauses, _)), correlation)
     , (remaining-expressions-plus-varRefs, tableExpressions, allVariablesExceptFromOuterQuery)
     ) -> (remaining-expressions-plus-varRefs'', tableExpressions', allVariablesExceptFromOuterQuery')
     where <?LimitOffsetClauses(None(), None())> limitOffsetClauses // if there is a LIMIT (or FETCH FIRST) and/or an OFFSET then we cannot push down any predicate without altering the result, in particular if the subquery has an ORDER BY
-    with new-variables := <filter(?ExpAsVar(_, _, _, <id>))> expAsVars
-       ; visible-variables-to-predicates := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery, new-variables)
-       ; (pushed-down-predicates, remaining-expressions-plus-varRefs'') := <foldl(try-push-down-predicate(|visible-variables-to-predicates))> (remaining-expressions-plus-varRefs, ([], []))
-       ; pushed-down-predicates' := <alltd(replace-varRef-with-expression(|expAsVars))> pushed-down-predicates
-       ; if <(?CreateOneGroup() + ?Some(GroupByClause(_))); !pushed-down-predicates'; not(?[])> groupByClause // add to HAVING clause if there is a GROUP BY and predicates to pushdown are not empty
-         then constraints' := constraints
-            ; predicate1 := <?[<id>] <+ to-conjunction; !ExpressionPlusType(<id>, BooleanTy())> pushed-down-predicates'
-            ; if <?Some(HavingClause(predicate2))> havingClause
-              then predicate3 := <to-conjunction; !ExpressionPlusType(<id>, BooleanTy())> [predicate2, predicate1]
-                 ; havingClause' := <Some(HavingClause(!predicate3))> havingClause
-              else havingClause' := Some(HavingClause(predicate1))
+    with if <?SelectClause(_, SelectList(expAsVars))> selectOrModifyClause
+         then new-variables := <filter(?ExpAsVar(_, _, _, <id>))> expAsVars
+            ; visible-variables-to-predicates := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery, new-variables)
+            ; (pushed-down-predicates, remaining-expressions-plus-varRefs'') := <foldl(try-push-down-predicate(|visible-variables-to-predicates))> (remaining-expressions-plus-varRefs, ([], []))
+            ; pushed-down-predicates' := <alltd(replace-varRef-with-expression(|expAsVars))> pushed-down-predicates
+            ; if <(?CreateOneGroup() + ?Some(GroupByClause(_))); !pushed-down-predicates'; not(?[])> groupByClause // add to HAVING clause if there is a GROUP BY and predicates to pushdown are not empty
+              then constraints' := constraints
+                 ; predicate1 := <?[<id>] <+ to-conjunction; !ExpressionPlusType(<id>, BooleanTy())> pushed-down-predicates'
+                 ; if <?Some(HavingClause(predicate2))> havingClause
+                   then predicate3 := <to-conjunction; !ExpressionPlusType(<id>, BooleanTy())> [predicate2, predicate1]
+                      ; havingClause' := <Some(HavingClause(!predicate3))> havingClause
+                   else havingClause' := Some(HavingClause(predicate1))
+                   end
+              else constraints' := Constraints(<conc> (subquery-constraints, pushed-down-predicates'))
+                 ; havingClause' := havingClause
               end
-         else constraints' := Constraints(<conc> (subquery-constraints, pushed-down-predicates'))
-            ; havingClause' := havingClause
+            ; visible-variables-to-lateral-query := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery)
+            ; normalizedQuery' := <NormalizedQuery(id, id, id, id, !constraints', id, !havingClause', id, id, id); push-down-predicates(|visible-variables-to-lateral-query)> normalizedQuery
+            ; derivedTable := <origin-track-forced(!DerivedTable(lateral, Subquery(normalizedQuery'), correlation))> t
+            ; tableExpressions' := <conc> (tableExpressions, [derivedTable])
+            ; allVariablesExceptFromOuterQuery' := <conc; make-set> (allVariablesExceptFromOuterQuery, new-variables)
+         else // INSERT / UPDATE / DELETE
+              remaining-expressions-plus-varRefs'' := remaining-expressions-plus-varRefs
+            ; tableExpressions' := <conc> (tableExpressions, [t])
+            ; allVariablesExceptFromOuterQuery' := allVariablesExceptFromOuterQuery
          end
-       ; visible-variables-to-lateral-query := <conc; make-set> (variablesOuterQuery, allVariablesExceptFromOuterQuery)
-       ; normalizedQuery' := <NormalizedQuery(id, id, id, id, !constraints', id, !havingClause', id, id, id); push-down-predicates(|visible-variables-to-lateral-query)> normalizedQuery
-       ; derivedTable := <origin-track-forced(!DerivedTable(lateral, Subquery(normalizedQuery'), correlation))> t
-       ; tableExpressions' := <conc> (tableExpressions, [derivedTable])
-       ; allVariablesExceptFromOuterQuery' := <conc; make-set> (allVariablesExceptFromOuterQuery, new-variables)
 
   try-push-down-predicates(|variablesOuterQuery):
     (

--- a/pgql-spoofax/trans/normalize.str
+++ b/pgql-spoofax/trans/normalize.str
@@ -60,7 +60,6 @@ rules
           norm-NEQ +
           norm-singleVertex +
           norm-parenthesized-match-single-path +
-          norm-VertexWithoutBrackets +
           norm-isNull +
           norm-case
         );
@@ -88,7 +87,11 @@ rules
   is-pgql11 = ?Pgql11Query(_, _, _, _, _, _, _, _)
   is-pgql13 = ?Query(_, _, _, _, _, _, _)
 
-  get-pgql11-deprecation = (?OutConn(None(), _) + ?InConn(None(), _) + ?UndirectedEdge(None(), _)); to-error-message(|"Use [-] instead of [--]")
+
+  get-pgql11-deprecation = error-for-two-dashes
+  get-pgql10-limitation  = error-for-two-dashes
+  error-for-two-dashes   = (?OutConn(None(), _) + ?InConn(None(), _) + ?UndirectedEdge(None(), _)); to-error-message(|"Use [-] instead of [--]")
+
   get-pgql11-deprecation = ?Pgql10AsignSymbol(); to-error-message(|"Use [AS] instead of [:=]")
 
   get-pgql11-deprecation = (?Legacy10Label(_) + get-pgql11-deprecation-helper(|"LABEL", 0, False())); to-error-message(|"Use [label(x)] instead of [x.label()]")
@@ -433,8 +436,6 @@ rules
 
   get-pgql13-errors:
     PathPattern2(Some(pathPatternPrefix1), PathPattern2(Some(pathPatternPrefix2), _)) -> <to-error-message(|"Nested path pattern prefix not allowed")> pathPatternPrefix2
-
-  norm-VertexWithoutBrackets = ?VertexWithoutBrackets(v); !Vertex(ElemContents(Some(RegularIdentifier(<origin-track-forced(<conc-strings> (v, <VERTEX_WITHOUT_BRACKETS>))>)), None(), None(), None()))
 
   norm-edgeContents = ?Some(EdgeContents(<id>))
 

--- a/pgql-tests/error-messages/legacy/pgql10/disabled-pgql10-features.spt
+++ b/pgql-tests/error-messages/legacy/pgql10/disabled-pgql10-features.spt
@@ -1,0 +1,10 @@
+module disabled-pgql10-features
+
+language pgql-lang
+
+test Double dash will in the future be repurposed for introducing a single-line comment [[
+
+  SELECT 1
+  WHERE (n) [[-- (o)]], (n) [[--> (o)]], (n) [[<-- (o)]]
+
+]] error like "Use [-] instead of [--]" at #1, #2, #3

--- a/pgql-tests/error-messages/modify.spt
+++ b/pgql-tests/error-messages/modify.spt
@@ -17,6 +17,13 @@ test INSERT/UPDATE/DELETE subquery not allowed (2) [[
 
 ]] error like "SELECT clause expected here" at #1
 
+test INSERT/UPDATE/DELETE subquery not allowed (3) [[
+
+  SELECT 123
+    FROM LATERAL ( [[ UPDATE x SET ( x.prop = 3 ) ]] FROM MATCH (x) )
+
+]] error like "SELECT clause expected here" at #1
+
 test Set a property that is grouped by [[
 
     UPDATE n SET ( [[n.prop]] = 123 )


### PR DESCRIPTION
Decided to keep supporting PGQL 0.9 and PGQL 1.0 after all and only desupport these two features:

- get rid of vertex patterns that have no parentheses, which was a feature that was part of the PGQL 0.9 spec `WHERE n -> m, n.prop > m.prop`.
- give a nice error message when `--`, `<--` and `-->` is used in PGQL 0.9 or PGQL 1.0 just like we already do for PGQL 1.1+. This because we want to repurpose the `--` to introduce a single-line comment and to be able to implement that we need to remove it from all PGQL versions.

This PR is also fixing two unrelated bugs:
- fix regression: x.* in combination with ONE ROW PER VERTEX/STEP was broken (when variable `x` is one of the iterator variables)
- fix bug: LATERAL containing INSERT/UPDATE/DELETE would crash the parser and now it's giving a nicer error message

PGQL parser version 2.0.6.x
