### PR TITLE
Fix pretty printer generating invalid queries when pushing down a WHERE clause into a MATCH that is followed by a LATERAL

### DIFF
--- a/pgql-spoofax/syntax/GraphPattern.sdf3
+++ b/pgql-spoofax/syntax/GraphPattern.sdf3
@@ -33,7 +33,7 @@ context-free syntax
   Connection.ParenthesizedPath = <( <RelaxedPathPattern> <WhereClause?> <CostClause?> )<PathQuantifier?>>
 
   PathPattern.PathPattern2 = PathPatternPrefix? OptionallyParenthesizedPathPattern
-  OptionallyParenthesizedPathPattern = <( <PathPattern> )>
+  OptionallyParenthesizedPathPattern.ParenthesizedPathPattern = <( <PathPattern> <WhereClause?> )>
   OptionallyParenthesizedPathPattern.PathPattern = Vertex EdgeVertex+
 
   CostClause.CostClause = <COST <Exp>> {case-insensitive}

--- a/pgql-spoofax/syntax/pgql-lang.sdf3
+++ b/pgql-spoofax/syntax/pgql-lang.sdf3
@@ -51,7 +51,7 @@ context-free syntax
 
   GraphMatch.GraphMatch = MatchKeyword? PathPattern OptionalGraphMatchParts?
 
-  GraphMatch.ParenthesizedGraphMatch = <MATCH ( <PathPattern>, <{PathPattern ","}+> ) <OptionalGraphMatchParts?>> {case-insensitive}
+  GraphMatch.ParenthesizedGraphMatch = <MATCH ( <PathPattern>, <{PathPattern ","}+> <WhereClause?> ) <OptionalGraphMatchParts?>> {case-insensitive}
 
   MatchKeyword.MatchKeyword = <MATCH> {case-insensitive}
 

--- a/pgql-spoofax/trans/normalize.str
+++ b/pgql-spoofax/trans/normalize.str
@@ -118,7 +118,7 @@ rules
   get-pgql13-errors      = ?GraphMatch(None(), _, _); to-error-message(|"Missing MATCH keyword at start of pattern")
 
   get-pgql13-errors:
-    ParenthesizedGraphMatch(_, _, optionalGraphMatchParts) -> <error-for-rows-clause-when-multiple-path-patterns> rowsPerMatch
+    ParenthesizedGraphMatch(_, _, _, optionalGraphMatchParts) -> <error-for-rows-clause-when-multiple-path-patterns> rowsPerMatch
     where rowsPerMatch := <get-RowsPerMatch; ?Some(<id>)> optionalGraphMatchParts
         ; <is-not-one-row-per-match> rowsPerMatch
 
@@ -128,7 +128,8 @@ rules
   get-pgql13-errors:
     graphMatch -> <to-error-message(|"ONE ROW PER VERTEX or STEP is only supported in combination with an edge pattern and quantifier")> rowsPerMatch
     where <?GraphMatch(_, SingleVertex(_), Some(OptionalGraphMatchParts1(rowsPerMatch, _))) +
-           ?GraphMatch(_, PathPattern2(_, SingleVertex(_)), Some(OptionalGraphMatchParts1(rowsPerMatch, _)))> graphMatch
+           ?GraphMatch(_, PathPattern2(_, SingleVertex(_)), Some(OptionalGraphMatchParts1(rowsPerMatch, _))) +
+           ?GraphMatch(_, PathPattern2(_, ParenthesizedPathPattern(SingleVertex(_), _)), Some(OptionalGraphMatchParts1(rowsPerMatch, _)))> graphMatch
         ; <is-not-one-row-per-match> rowsPerMatch
 
   get-pgql13-errors:
@@ -159,8 +160,8 @@ rules
 
   get-GraphTable-restriction = ?Labels(c@Colon(), _); !c; to-error-message(|"GRAPH_TABLE restriction: use IS instead of :")
 
-  get-GraphTable-restriction = (?GraphMatch(_, _, _) +  ?ParenthesizedGraphMatch(_, _, _)); to-error-message(|<wrap-match-in-graph-table-error>)
-  get-GraphTable-restriction = (?GraphMatch(_, _, _) +  ?ParenthesizedGraphMatch(_, _, _)); to-error-message(|<wrap-match-in-graph-table-error>)
+  get-GraphTable-restriction = (?GraphMatch(_, _, _) +  ?ParenthesizedGraphMatch(_, _, _, _)); to-error-message(|<wrap-match-in-graph-table-error>)
+  get-GraphTable-restriction = (?GraphMatch(_, _, _) +  ?ParenthesizedGraphMatch(_, _, _, _)); to-error-message(|<wrap-match-in-graph-table-error>)
   wrap-match-in-graph-table-error = !"GRAPH_TABLE restriction: wrap top-level MATCH in GRAPH_TABLE"
 
   get-GraphTable-restriction = ?LimitClause(x); to-error-message(|$<GRAPH_TABLE restriction: use FETCH FIRST <<origin-text> x> ROWS ONLY instead of LIMIT <<origin-text> x>>)
@@ -240,9 +241,9 @@ rules
          end
 
   get-graph-name = ?GraphMatch(_, _, Some(OptionalGraphMatchParts1(_, Some(OnClause(<id>)))))
-                 + ?ParenthesizedGraphMatch(_, _, Some(OptionalGraphMatchParts1(_, Some(OnClause(<id>)))))
+                 + ?ParenthesizedGraphMatch(_, _, _, Some(OptionalGraphMatchParts1(_, Some(OnClause(<id>)))))
                  + ?GraphMatch(_, _, Some(OptionalGraphMatchParts2(OnClause(<id>), _)))
-                 + ?ParenthesizedGraphMatch(_, _, Some(OptionalGraphMatchParts2(OnClause(<id>), _)))
+                 + ?ParenthesizedGraphMatch(_, _, _, Some(OptionalGraphMatchParts2(OnClause(<id>), _)))
                  + ?GraphTable(Some(<id>), _, _)
                  + ?GraphName(<id>) // for lateral subqueries that are already normalized at this point
 
@@ -254,9 +255,9 @@ rules
     ast -> errors
     with if <oncetd(?OnClause(_) + ?GraphTable(_, _, _))> ast
          then clausesWithMissingGraphName := <collect(?GraphMatch(_, _, Some(OptionalGraphMatchParts1(_, None())))
-						                            + ?ParenthesizedGraphMatch(_, _, Some(OptionalGraphMatchParts1(_, None())))
+						                            + ?ParenthesizedGraphMatch(_, _, _, Some(OptionalGraphMatchParts1(_, None())))
 						                            + ?GraphMatch(_, _, None())
-						                            + ?ParenthesizedGraphMatch(_, _, None())
+						                            + ?ParenthesizedGraphMatch(_, _, _, None())
 						                            + ?GraphTable(None(), _, _))> ast
             ; errors := <map(?GraphTable(_, _, _); to-error-message(|"GRAPH_TABLE restriction: graph name required") <+ to-error-message(|"Missing graph name"))> clausesWithMissingGraphName
          else errors := []
@@ -335,6 +336,8 @@ rules
 
   get-pgql13-errors:
     PathPattern2(Some(pathPatternPrefix1), PathPattern2(Some(pathPatternPrefix2), _)) -> <to-error-message(|"Nested path pattern prefix not allowed")> pathPatternPrefix2
+  get-pgql13-errors:
+    PathPattern2(Some(pathPatternPrefix1), ParenthesizedPathPattern(PathPattern2(Some(pathPatternPrefix2), _), _)) -> <to-error-message(|"Nested path pattern prefix not allowed")> pathPatternPrefix2
 
   norm-edgeContents = ?Some(EdgeContents(<id>))
 
@@ -376,7 +379,7 @@ rules
                  ; tableExpressions' := [pathPatternsWithRowsPerMatch]
               end
          else <?[x|xs]> tableExpressions
-            ; if <?GraphMatch(_, _, _) + ?ParenthesizedGraphMatch(_, _, _)> x
+            ; if <?GraphMatch(_, _, _) + ?ParenthesizedGraphMatch(_, _, _, _)> x
               then graphMatches' := <conc> (graphMatches, [x])
                  ; tableExpressions' := <normalize-table-expressions(|variable-counter, graphMatches')> xs
               else x' := <normalize-table-expression(|variable-counter)> x
@@ -392,8 +395,8 @@ rules
 
   get-pathPatternsAndRowsPerMatch-and-normalize(|variable-counter) = map(get-pathPatternsAndRowsPerMatch); concat; norm-matchElems-common(|variable-counter, None())
 
-  get-pathPatternsAndRowsPerMatch = ?GraphMatch(_, pathPattern, optionalGraphMatchParts); ![PathPatternAndRowsPerMatch(pathPattern, <get-RowsPerMatch> optionalGraphMatchParts)]
-                                  + ?ParenthesizedGraphMatch(pathPattern1, otherPathPatterns, optionalGraphMatchParts); !([pathPattern1], otherPathPatterns); conc; map(!PathPatternAndRowsPerMatch(<id>, <get-RowsPerMatch> optionalGraphMatchParts))
+  get-pathPatternsAndRowsPerMatch = ?GraphMatch(_, pathPattern, optionalGraphMatchParts); ![PathPatternAndRowsPerMatch(pathPattern, <get-RowsPerMatch> optionalGraphMatchParts, None())]
+                                  + ?ParenthesizedGraphMatch(pathPattern1, otherPathPatterns, whereClause, optionalGraphMatchParts); !([pathPattern1], otherPathPatterns); conc; map(!PathPatternAndRowsPerMatch(<id>, <get-RowsPerMatch> optionalGraphMatchParts, whereClause))
 
   // PGQL 1.1 and 1.2
   norm-matchElems(|variable-counter):
@@ -413,14 +416,15 @@ rules
        ; vertices := <collect-outside-repeated-path(?Vertex(ElemContents(Some(<id>), _, _, _)); !Vertex(<id>)); remove-duplicate-vertices; !Vertices(<id>)> pathPatterns
        ; connections := <get-connections-from-paths(|variable-counter, None(), keepClause)> pathPatterns
 
-       ; non-inlined-constraints := <filter(?Constraint(<id>))> matchElems // PGQL 1.0 only
+       ; non-inlined-constraints1 := <filter(?Constraint(<id>))> matchElems // PGQL 1.0 only
+       ; non-inlined-constraints2 := <collect-outside-repeated-path(?WhereClause(<id>)); Hd; ![<id>] <+ ![]> matchElems // for parenthesized graph match
        ; inlined-constraints-for-vertices := <collect-outside-repeated-path(?Vertex(<id>))
                                            ; map(get-inlined-constraints); concat> pathPatterns
        ; inlined-constraints-for-edges := <collect-outside-repeated-path(?OutConn(<id>, None())
                                                                        + ?InConn(<id>, None())
                                                                        + ?UndirectedEdge(<id>, None()))
                                         ; filter(get-inlined-constraints); concat> pathPatterns
-       ; constraints := <conc; flatten-list; !Constraints(<id>)> (inlined-constraints-for-vertices, inlined-constraints-for-edges, non-inlined-constraints)
+       ; constraints := <conc; flatten-list; !Constraints(<id>)> (inlined-constraints-for-vertices, inlined-constraints-for-edges, non-inlined-constraints1, non-inlined-constraints2)
 
   collect-outside-repeated-path(s) = collect-but-preserve-order(ParenthesizedPath + s); remove-all(ParenthesizedPath)
 
@@ -469,26 +473,29 @@ rules
     [] -> []
 
   get-connections-from-paths(|variable-counter, _, keepClause):
-    [PathPatternAndRowsPerMatch(pathPattern, rowsPerMatch)|otherPaths] -> <get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause)> [pathPattern|otherPaths]
+    [PathPatternAndRowsPerMatch(pathPattern, rowsPerMatch, _)|otherPaths] -> <get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause)> [pathPattern|otherPaths]
 
   // first path pattern has only one vertex => ignore it
   get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause):
     [PathPattern2(_, PathPattern(_, []))|otherPaths] -> <get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause)> otherPaths
+  get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause):
+    [PathPattern2(_, ParenthesizedPathPattern(PathPattern2(_, PathPattern(_, [])), _))|otherPaths] -> <get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause)> otherPaths
 
   // first path pattern has more than one vertex
   get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause):
     [PathPattern2(pathPatternPrefix, pathPattern)|otherPaths] -> result
-    where <not(?PathPattern(_, []))> pathPattern
+    where pathPattern' := <try(?ParenthesizedPathPattern(PathPattern2(_, <id>), _))> pathPattern
+    where <not(?PathPattern(_, []))> pathPattern'
     with pathPatternPrefix' := <?Some(KeepClause(<id>)); !Some(<id>) <+ !pathPatternPrefix> keepClause
-       ; if <contains-edge-pattern-with-quantifier + !rowsPerMatch; ?Some(<id>); is-not-one-row-per-match + !pathPatternPrefix'; not(?None() + ?Some(AllPathSearch(_, _)))> pathPattern // path pattern has a quantifier or it has a search prefix other than ALL or it has a graph table rows clause other than ONE ROW PER MATCH
+       ; if <contains-edge-pattern-with-quantifier + !rowsPerMatch; ?Some(<id>); is-not-one-row-per-match + !pathPatternPrefix'; not(?None() + ?Some(AllPathSearch(_, _)))> pathPattern' // path pattern has a quantifier or it has a search prefix other than ALL or it has a graph table rows clause other than ONE ROW PER MATCH
          then pathFindingGoal := <to-pathFindingGoal> pathPatternPrefix'
             ; topKAnyAll := <to-topKAnyAll> pathPatternPrefix'
             ; pathMode := <to-pathMode> pathPatternPrefix'
-            ; result := <get-connections-from-quantified-path-patterns(|variable-counter, rowsPerMatch, keepClause)> (pathFindingGoal, topKAnyAll, pathMode, pathPattern, otherPaths)
+            ; result := <get-connections-from-quantified-path-patterns(|variable-counter, rowsPerMatch, keepClause)> (pathFindingGoal, topKAnyAll, pathMode, pathPattern', otherPaths)
          else topKAnyAll := None()
             ; pathFindingGoal := None()
             ; pathMode := Walk()
-            ; edges := <pathPattern-to-connections(|variable-counter, pathFindingGoal, topKAnyAll, pathMode, rowsPerMatch)> pathPattern
+            ; edges := <pathPattern-to-connections(|variable-counter, pathFindingGoal, topKAnyAll, pathMode, rowsPerMatch)> pathPattern'
             ; edgesTailPaths := <get-connections-from-paths(|variable-counter, rowsPerMatch, keepClause)> otherPaths
             ; result := <conc> (edges, edgesTailPaths)
          end
@@ -768,7 +775,7 @@ rules // GRAPH_TABLE
                        ?Some(GraphTableColumnsClause(<id>)); map(?AllProperties(_, _) + norm-ExpAsVar-for-select-clause); ?list; !columnsClause; origin-track-forced(!SelectList(list))> columnsClause
        ; selectClause := <origin-track-forced(!SelectClause(distinct, selectList))> selectList
        ; graphName' := <?None() + ?Some(<id>); !Some(GraphName(<id>))> graphName
-       ; graphPattern' := <map(!PathPatternAndRowsPerMatch(<id>, rowsClause)); norm-matchElems-common(|variable-counter, keepClause)> pathPatterns
+       ; graphPattern' := <map(!PathPatternAndRowsPerMatch(<id>, rowsClause, None())); norm-matchElems-common(|variable-counter, keepClause)> pathPatterns
        ; tableExpressions := [ graphPattern' ]
        ; whereClause' := <?Some(WhereClause(<id>)); !Constraints([<id>]) <+ ?None(); !Constraints([])> whereClause
        ; groupBy := None()

--- a/pgql-spoofax/trans/normalized-signatures.str
+++ b/pgql-spoofax/trans/normalized-signatures.str
@@ -67,7 +67,7 @@ signature constructors // for the normalized AST (see trans/normalize.str)
 
   TableExpressionsAndGraphName : GraphPattern * Name * WhereClause -> TableExpressionsAndGraphName
 
-  PathPatternAndRowsPerMatch   : PathPattern * RowsPerMatch -> PathPatternAndRowsPerMatch
+  PathPatternAndRowsPerMatch   : PathPattern * RowsPerMatch * WhereClause -> PathPatternAndRowsPerMatch
 
   SelectingAllProperties       : Boolean -> SelectingAllProperties
 

--- a/pgql-tests/error-messages/graph_table.spt
+++ b/pgql-tests/error-messages/graph_table.spt
@@ -327,7 +327,7 @@ test Restriction: aggregation with vertex/edge input [[
 test Restriction: TIMEZONE [[
 
   SELECT CAST(time '11:30:00' AS [[TiMe WiTh TiMeZoNe]])
-  FROM GRAPH_TABLE ( g MATCH (n) COLUMNS ( n.prop ) ) 
+  FROM GRAPH_TABLE ( g MATCH (n) COLUMNS ( n.prop ) )
 
 ]] error like "GRAPH_TABLE restriction: TIMEZONE should be TIME ZONE (with space)" at #1
 

--- a/pgql-tests/error-messages/variable-length-paths.spt
+++ b/pgql-tests/error-messages/variable-length-paths.spt
@@ -504,7 +504,7 @@ test ONE ROW PER EDGE duplicate variable (5) [[
 test ONE ROW PER STEP duplicate variable (1) [[
 
   SELECT 1
-    FROM MATCH ANY ([[a]]) -[ [[e]] ]-> ([[b]]) ONE ROW PER STEP ([[a]], [[e]], [[b]])
+    FROM MATCH ANY ([[a]]) -[ [[e]] ]->* ([[b]]) ONE ROW PER STEP ([[a]], [[e]], [[b]])
 
 ]] error like "Duplicate variable" at #1, #2, #3, #4, #5, #6
 


### PR DESCRIPTION
Fix is that the pretty printer now adds the right parentheses around such MATCH clauses: `MATCH ( ... WHERE ...)` instead of `MATCH ... WHERE ...`

Additionally, the missing WHERE clause within parentheses had to be added to the syntax, which was planned since the start but never implemented.