### PR TITLE
Expose unique names for variables

### DIFF
--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/ExpAsVar.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/ExpAsVar.java
@@ -37,7 +37,25 @@ public class ExpAsVar extends QueryVariable {
    *          upper cased.
    */
   public ExpAsVar(QueryExpression exp, String name, boolean anonymous, String nameOriginText) {
-    super(name, anonymous);
+    this(exp, name, null, anonymous, nameOriginText);
+  }
+
+  /**
+   * @param exp
+   *          an expression
+   * @param name
+   *          the name with which the the element can be referred to in the result set
+   * @param uniqueName
+   *          a query-wide unique generated name for the variable
+   * @param anonymous
+   *          false if the name was provided via the query (i.e. exp AS name), true if the name was not provided via the
+   *          query (i.e. exp) but via some other mechanism
+   * @param nameOriginText
+   *          the text of the column name as it appear in the query string. Should be NULL unless name was unquoted and
+   *          upper cased.
+   */
+  public ExpAsVar(QueryExpression exp, String name, String uniqueName, boolean anonymous, String nameOriginText) {
+    super(name, uniqueName, anonymous);
     this.exp = exp;
     this.nameOriginText = nameOriginText;
   }

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryEdge.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryEdge.java
@@ -7,8 +7,16 @@ import static oracle.pgql.lang.ir.PgqlUtils.printIdentifier;
 
 public class QueryEdge extends VertexPairConnection {
 
+  private QueryVariable correlationEdgeInOuterQuery;
+
   public QueryEdge(QueryVertex src, QueryVertex dst, String name, boolean anonymous, Direction direction) {
-    super(src, dst, name, anonymous, direction);
+    this(src, dst, name, null, anonymous, direction, null);
+  }
+
+  public QueryEdge(QueryVertex src, QueryVertex dst, String name, String uniqueName, boolean anonymous,
+      Direction direction, QueryVariable correlationEdgeInOuterQuery) {
+    super(src, dst, name, uniqueName, anonymous, direction);
+    this.correlationEdgeInOuterQuery = correlationEdgeInOuterQuery;
   }
 
   @Override
@@ -18,6 +26,14 @@ public class QueryEdge extends VertexPairConnection {
 
   public boolean isDirected() {
     return direction != Direction.ANY;
+  }
+
+  public QueryVariable getCorrelationEdgeInOuterQuery() {
+    return correlationEdgeInOuterQuery;
+  }
+
+  public void setCorrelationEdgeInOuterQuery(QueryVariable correlationEdgeInOuterQuery) {
+    this.correlationEdgeInOuterQuery = correlationEdgeInOuterQuery;
   }
 
   @Override

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryVariable.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryVariable.java
@@ -14,10 +14,20 @@ public abstract class QueryVariable {
 
   protected String name;
 
+  /**
+   * Generated name that is unique even across subqueries
+   */
+  protected String uniqueName;
+
   protected boolean anonymous;
 
   public QueryVariable(String name, boolean anonymous) {
+    this(name, null, anonymous);
+  }
+
+  public QueryVariable(String name, String uniqueName, boolean anonymous) {
     this.name = name;
+    this.uniqueName = uniqueName;
     this.anonymous = anonymous;
   }
 
@@ -31,6 +41,14 @@ public abstract class QueryVariable {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public String getUniqueName() {
+    return uniqueName;
+  }
+
+  public void setUniqueName(String uniqueName) {
+    this.uniqueName = uniqueName;
   }
 
   public boolean isAnonymous() {

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryVertex.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/QueryVertex.java
@@ -7,13 +7,28 @@ import static oracle.pgql.lang.ir.PgqlUtils.printIdentifier;
 
 public class QueryVertex extends QueryVariable {
 
+  private QueryVariable correlationVertexInOuterQuery;
+
   public QueryVertex(String name, boolean anonymous) {
-    super(name, anonymous);
+    this(name, null, anonymous, null);
+  }
+
+  public QueryVertex(String name, String uniqueName, boolean anonymous, QueryVariable correlationVertexInOuterQuery) {
+    super(name, uniqueName, anonymous);
+    this.correlationVertexInOuterQuery = correlationVertexInOuterQuery;
   }
 
   @Override
   public VariableType getVariableType() {
     return VariableType.VERTEX;
+  }
+
+  public QueryVariable getCorrelationVertexInOuterQuery() {
+    return correlationVertexInOuterQuery;
+  }
+
+  public void setCorrelationVertexInOuterQuery(QueryVariable correlationVertexInOuterQuery) {
+    this.correlationVertexInOuterQuery = correlationVertexInOuterQuery;
   }
 
   @Override

--- a/graph-query-ir/src/main/java/oracle/pgql/lang/ir/VertexPairConnection.java
+++ b/graph-query-ir/src/main/java/oracle/pgql/lang/ir/VertexPairConnection.java
@@ -12,7 +12,12 @@ public abstract class VertexPairConnection extends QueryVariable {
   protected Direction direction;
 
   public VertexPairConnection(QueryVertex src, QueryVertex dst, String name, boolean anonymous, Direction direction) {
-    super(name, anonymous);
+    this(src, dst, name, null, anonymous, direction);
+  }
+
+  public VertexPairConnection(QueryVertex src, QueryVertex dst, String name, String uniqueName, boolean anonymous,
+      Direction direction) {
+    super(name, uniqueName, anonymous);
     this.src = src;
     this.dst = dst;
     this.direction = direction;

--- a/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
@@ -140,6 +140,9 @@ public class SpoofaxAstToGraphQuery {
 
   private static final int POS_VERTEX_NAME = 0;
   private static final int POS_VERTEX_ORIGIN_OFFSET = 1;
+  private static final int POS_VERTEX_CORRELATION = 2;
+  private static final int POS_VERTEX_CORRELATION_EXP = 0;
+  private static final int POS_VERTEX_CORRELATION_EXP_VARREF = 0;
 
   private static final int POS_EDGE_SRC = 0;
   private static final int POS_EDGE_NAME = 1;
@@ -297,8 +300,8 @@ public class SpoofaxAstToGraphQuery {
 
     switch (selectOrUpdate) {
       case "SelectClause":
-        return new SelectQuery(commonPathExpressions, projection, graphName, tableExpressions, constraints, groupBy, having,
-            orderBy, limit, offset);
+        return new SelectQuery(commonPathExpressions, projection, graphName, tableExpressions, constraints, groupBy,
+            having, orderBy, limit, offset);
       case "ModifyClause":
         return new ModifyQuery(commonPathExpressions, modifications, graphName, tableExpressions, constraints, groupBy,
             having, orderBy, limit, offset);
@@ -422,8 +425,10 @@ public class SpoofaxAstToGraphQuery {
     switch (constructorName) {
       case "VertexInsertion": {
         String vertexName = getString(insertionT.getSubterm(POS_VERTEX_INSERTION_NAME));
-        QueryVertex vertex = new QueryVertex(vertexName, false);
         IStrategoTerm originOffset = insertionT.getSubterm(POS_VERTEX_INSERTION_ORIGIN_OFFSET);
+        String uniqueName = originOffset.toString();
+        QueryVertex correlationVertexInOuterQuery = null;
+        QueryVertex vertex = new QueryVertex(vertexName, uniqueName, false, correlationVertexInOuterQuery);
         ctx.addVar(vertex, vertexName, originOffset);
 
         IStrategoTerm labelsT = insertionT.getSubterm(POS_VERTEX_INSERTION_LABELS);
@@ -443,8 +448,11 @@ public class SpoofaxAstToGraphQuery {
         IStrategoTerm dstVarRefT = insertionT.getSubterm(POS_EDGE_INSERTION_DST).getSubterm(POS_EXP_PLUS_TYPE_EXP);
         QueryVertex dst = dereferenceQueryVertex(getVariable(ctx, dstVarRefT));
 
-        QueryEdge edge = new QueryEdge(src, dst, edgeName, false, Direction.OUTGOING);
         IStrategoTerm originOffset = insertionT.getSubterm(POS_EDGE_INSERTION_ORIGIN_OFFSET);
+        String uniqueName = originOffset.toString();
+        QueryEdge correlationEdgeInOuterQuery = null;
+        QueryEdge edge = new QueryEdge(src, dst, edgeName, uniqueName, false, Direction.OUTGOING,
+            correlationEdgeInOuterQuery);
         ctx.addVar(edge, edgeName, originOffset);
 
         IStrategoTerm labelsT = insertionT.getSubterm(POS_EDGE_INSERTION_LABELS);
@@ -578,9 +586,18 @@ public class SpoofaxAstToGraphQuery {
     for (IStrategoTerm vertexT : verticesT) {
       String vertexName = getString(vertexT.getSubterm(POS_VERTEX_NAME));
       IStrategoTerm originOffset = vertexT.getSubterm(POS_VERTEX_ORIGIN_OFFSET);
+      String uniqueName = originOffset.toString();
       boolean anonymous = vertexName.contains(GENERATED_VAR_SUBSTR);
 
-      QueryVertex vertex = new QueryVertex(vertexName, anonymous);
+      IStrategoTerm correlationT = vertexT.getSubterm(POS_VERTEX_CORRELATION);
+      QueryVariable correlationVertexInOuterQuery = null;
+      if (!isNone(correlationT)) {
+        IStrategoTerm varRefT = correlationT.getSubterm(POS_VERTEX_CORRELATION_EXP)
+            .getSubterm(POS_VERTEX_CORRELATION_EXP_VARREF);
+        correlationVertexInOuterQuery = getVariable(ctx, varRefT);
+      }
+
+      QueryVertex vertex = new QueryVertex(vertexName, uniqueName, anonymous, correlationVertexInOuterQuery);
       ctx.addVar(vertex, vertexName, originOffset);
       vertices.add(vertex);
     }
@@ -642,12 +659,14 @@ public class SpoofaxAstToGraphQuery {
     String dstName = getString(edgeT.getSubterm(POS_EDGE_DST));
     Direction direction = getDirection(edgeT.getSubterm(POS_EDGE_DIRECTION));
     IStrategoTerm originOffset = edgeT.getSubterm(POS_EDGE_ORIGIN_OFFSET);
+    String uniqueName = originOffset.toString();
+    QueryEdge correlationEdgeInOuterQuery = null; // not supported for now
 
     QueryVertex src = getQueryVertex(vertexMap, srcName);
     QueryVertex dst = getQueryVertex(vertexMap, dstName);
 
-    QueryEdge edge = name.contains(GENERATED_VAR_SUBSTR) ? new QueryEdge(src, dst, name, true, direction)
-        : new QueryEdge(src, dst, name, false, direction);
+    boolean anonymous = name.contains(GENERATED_VAR_SUBSTR);
+    QueryEdge edge = new QueryEdge(src, dst, name, uniqueName, anonymous, direction, correlationEdgeInOuterQuery);
 
     ctx.addVar(edge, name, originOffset);
     return edge;
@@ -838,8 +857,10 @@ public class SpoofaxAstToGraphQuery {
       TranslationContext ctx) {
     IStrategoTerm vertexVariableT = rowsPerMatchT.getSubterm(variablePosition);
     String vertexName = getString(vertexVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_NAME));
-    QueryVertex vertex = new QueryVertex(vertexName, false);
     IStrategoTerm originOffset = vertexVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_ORIGIN_OFFSET);
+    String uniqueName = originOffset.toString();
+    QueryVertex correlationVertexInOuterQuery = null;
+    QueryVertex vertex = new QueryVertex(vertexName, uniqueName, false, correlationVertexInOuterQuery);
     ctx.addVar(vertex, vertexName, originOffset);
     return vertex;
   }
@@ -848,8 +869,10 @@ public class SpoofaxAstToGraphQuery {
       TranslationContext ctx) {
     IStrategoTerm edgeVariableT = rowsPerMatchT.getSubterm(variablePosition);
     String edgeName = getString(edgeVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_NAME));
-    QueryEdge edge = new QueryEdge(null, null, edgeName, false, null);
     IStrategoTerm originOffset = edgeVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_ORIGIN_OFFSET);
+    String uniqueName = originOffset.toString();
+    QueryEdge correlationEdgeInOuterQuery = null;
+    QueryEdge edge = new QueryEdge(null, null, edgeName, uniqueName, false, null, correlationEdgeInOuterQuery);
     ctx.addVar(edge, edgeName, originOffset);
     return edge;
   }
@@ -931,8 +954,9 @@ public class SpoofaxAstToGraphQuery {
       boolean anonymous = ((IStrategoAppl) expAsVarT.getSubterm(POS_EXPASVAR_ANONYMOUS)).getConstructor().getName()
           .equals("Anonymous");
       IStrategoTerm originOffset = expAsVarT.getSubterm(POS_EXPASVAR_ORIGIN_OFFSET);
+      String uniqueName = originOffset.toString();
 
-      ExpAsVar expAsVar = new ExpAsVar(exp, varName, anonymous, originName);
+      ExpAsVar expAsVar = new ExpAsVar(exp, varName, uniqueName, anonymous, originName);
       expAsVars.add(expAsVar);
       ctx.addVar(expAsVar, varName, originOffset);
     }

--- a/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
+++ b/pgql-lang/src/main/java/oracle/pgql/lang/SpoofaxAstToGraphQuery.java
@@ -426,7 +426,7 @@ public class SpoofaxAstToGraphQuery {
       case "VertexInsertion": {
         String vertexName = getString(insertionT.getSubterm(POS_VERTEX_INSERTION_NAME));
         IStrategoTerm originOffset = insertionT.getSubterm(POS_VERTEX_INSERTION_ORIGIN_OFFSET);
-        String uniqueName = originOffset.toString();
+        String uniqueName = createUniqueName(vertexName, originOffset);
         QueryVertex correlationVertexInOuterQuery = null;
         QueryVertex vertex = new QueryVertex(vertexName, uniqueName, false, correlationVertexInOuterQuery);
         ctx.addVar(vertex, vertexName, originOffset);
@@ -449,7 +449,7 @@ public class SpoofaxAstToGraphQuery {
         QueryVertex dst = dereferenceQueryVertex(getVariable(ctx, dstVarRefT));
 
         IStrategoTerm originOffset = insertionT.getSubterm(POS_EDGE_INSERTION_ORIGIN_OFFSET);
-        String uniqueName = originOffset.toString();
+        String uniqueName = createUniqueName(edgeName, originOffset);
         QueryEdge correlationEdgeInOuterQuery = null;
         QueryEdge edge = new QueryEdge(src, dst, edgeName, uniqueName, false, Direction.OUTGOING,
             correlationEdgeInOuterQuery);
@@ -586,7 +586,7 @@ public class SpoofaxAstToGraphQuery {
     for (IStrategoTerm vertexT : verticesT) {
       String vertexName = getString(vertexT.getSubterm(POS_VERTEX_NAME));
       IStrategoTerm originOffset = vertexT.getSubterm(POS_VERTEX_ORIGIN_OFFSET);
-      String uniqueName = originOffset.toString();
+      String uniqueName = createUniqueName(vertexName, originOffset);
       boolean anonymous = vertexName.contains(GENERATED_VAR_SUBSTR);
 
       IStrategoTerm correlationT = vertexT.getSubterm(POS_VERTEX_CORRELATION);
@@ -659,7 +659,7 @@ public class SpoofaxAstToGraphQuery {
     String dstName = getString(edgeT.getSubterm(POS_EDGE_DST));
     Direction direction = getDirection(edgeT.getSubterm(POS_EDGE_DIRECTION));
     IStrategoTerm originOffset = edgeT.getSubterm(POS_EDGE_ORIGIN_OFFSET);
-    String uniqueName = originOffset.toString();
+    String uniqueName = createUniqueName(name, originOffset);
     QueryEdge correlationEdgeInOuterQuery = null; // not supported for now
 
     QueryVertex src = getQueryVertex(vertexMap, srcName);
@@ -858,7 +858,7 @@ public class SpoofaxAstToGraphQuery {
     IStrategoTerm vertexVariableT = rowsPerMatchT.getSubterm(variablePosition);
     String vertexName = getString(vertexVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_NAME));
     IStrategoTerm originOffset = vertexVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_ORIGIN_OFFSET);
-    String uniqueName = originOffset.toString();
+    String uniqueName = createUniqueName(vertexName, originOffset);
     QueryVertex correlationVertexInOuterQuery = null;
     QueryVertex vertex = new QueryVertex(vertexName, uniqueName, false, correlationVertexInOuterQuery);
     ctx.addVar(vertex, vertexName, originOffset);
@@ -870,7 +870,7 @@ public class SpoofaxAstToGraphQuery {
     IStrategoTerm edgeVariableT = rowsPerMatchT.getSubterm(variablePosition);
     String edgeName = getString(edgeVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_NAME));
     IStrategoTerm originOffset = edgeVariableT.getSubterm(POS_ROWS_PER_MATCH_VARIABLE_ORIGIN_OFFSET);
-    String uniqueName = originOffset.toString();
+    String uniqueName = createUniqueName(edgeName, originOffset);
     QueryEdge correlationEdgeInOuterQuery = null;
     QueryEdge edge = new QueryEdge(null, null, edgeName, uniqueName, false, null, correlationEdgeInOuterQuery);
     ctx.addVar(edge, edgeName, originOffset);
@@ -954,7 +954,7 @@ public class SpoofaxAstToGraphQuery {
       boolean anonymous = ((IStrategoAppl) expAsVarT.getSubterm(POS_EXPASVAR_ANONYMOUS)).getConstructor().getName()
           .equals("Anonymous");
       IStrategoTerm originOffset = expAsVarT.getSubterm(POS_EXPASVAR_ORIGIN_OFFSET);
-      String uniqueName = originOffset.toString();
+      String uniqueName = createUniqueName(varName, originOffset);
 
       ExpAsVar expAsVar = new ExpAsVar(exp, varName, uniqueName, anonymous, originName);
       expAsVars.add(expAsVar);
@@ -962,5 +962,9 @@ public class SpoofaxAstToGraphQuery {
     }
     giveAnonymousVariablesUniqueHiddenName(expAsVars, ctx);
     return expAsVars;
+  }
+
+  private static String createUniqueName(String varName, IStrategoTerm originOffset) {
+    return varName + "_" + originOffset;
   }
 }

--- a/pgql-lang/src/test/java/oracle/pgql/lang/UniqueNameGenerationTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/UniqueNameGenerationTest.java
@@ -48,7 +48,7 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     GraphPattern graphPattern = result.getGraphQuery().getGraphPattern();
     QueryVertex vertexN1 = graphPattern.getVertices().iterator().next();
     assertEquals("N", vertexN1.getName());
-    assertEquals("(28,29)", vertexN1.getUniqueName());
+    assertEquals("N_(28,29)", vertexN1.getUniqueName());
 
     Exists existsSubquery = (Exists) graphPattern.getConstraints().iterator().next();
     Iterator<QueryVertex> it = existsSubquery.getQuery().getGraphPattern().getVertices().iterator();
@@ -56,11 +56,11 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     QueryVertex vertexM = it.next();
 
     assertEquals("N", vertexN2.getName());
-    assertEquals("(67,68)", vertexN2.getUniqueName());
-    assertEquals("(28,29)", vertexN2.getCorrelationVertexInOuterQuery().getUniqueName());
+    assertEquals("N_(67,68)", vertexN2.getUniqueName());
+    assertEquals("N_(28,29)", vertexN2.getCorrelationVertexInOuterQuery().getUniqueName());
 
     assertEquals("M", vertexM.getName());
-    assertEquals("(74,75)", vertexM.getUniqueName());
+    assertEquals("M_(74,75)", vertexM.getUniqueName());
     assertNull(vertexM.getCorrelationVertexInOuterQuery());
   }
 
@@ -75,10 +75,10 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     QueryEdge edgeE2 = (QueryEdge) it.next();
 
     assertEquals("E1", edgeE1.getName());
-    assertEquals("(32,34)", edgeE1.getUniqueName());
+    assertEquals("E1_(32,34)", edgeE1.getUniqueName());
 
     assertEquals("E2", edgeE2.getName());
-    assertEquals("(43,45)", edgeE2.getUniqueName());
+    assertEquals("E2_(43,45)", edgeE2.getUniqueName());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     OneRowPerVertex oneRowPerVertex = (OneRowPerVertex) path.getRowsPerMatch();
 
     assertEquals("V", oneRowPerVertex.getVertex().getName());
-    assertEquals("(54,55)", oneRowPerVertex.getVertex().getUniqueName());
+    assertEquals("V_(54,55)", oneRowPerVertex.getVertex().getUniqueName());
 
     result = pgql.parse("SELECT 1 FROM MATCH () ->{1,4} () ONE ROW PER EDGE (e)");
     assertTrue(result.isQueryValid());
@@ -101,7 +101,7 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     OneRowPerEdge oneRowPerEdge = (OneRowPerEdge) path.getRowsPerMatch();
 
     assertEquals("E", oneRowPerEdge.getEdge().getName());
-    assertEquals("(52,53)", oneRowPerEdge.getEdge().getUniqueName());
+    assertEquals("E_(52,53)", oneRowPerEdge.getEdge().getUniqueName());
 
     result = pgql.parse("SELECT 1 FROM MATCH () ->{1,4} () ONE ROW PER STEP (v1, e, v2)");
     assertTrue(result.isQueryValid());
@@ -111,11 +111,11 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     OneRowPerStep oneRowPerStep = (OneRowPerStep) path.getRowsPerMatch();
 
     assertEquals("V1", oneRowPerStep.getVertex1().getName());
-    assertEquals("(52,54)", oneRowPerStep.getVertex1().getUniqueName());
+    assertEquals("V1_(52,54)", oneRowPerStep.getVertex1().getUniqueName());
     assertEquals("E", oneRowPerStep.getEdge().getName());
-    assertEquals("(56,57)", oneRowPerStep.getEdge().getUniqueName());
+    assertEquals("E_(56,57)", oneRowPerStep.getEdge().getUniqueName());
     assertEquals("V2", oneRowPerStep.getVertex2().getName());
-    assertEquals("(59,61)", oneRowPerStep.getVertex2().getUniqueName());
+    assertEquals("V2_(59,61)", oneRowPerStep.getVertex2().getUniqueName());
   }
 
   @Test
@@ -133,10 +133,10 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     QueryEdge edgeE = edgeInsertion.getEdge();
 
     assertEquals("V", vertexV.getName());
-    assertEquals("(14,15)", vertexV.getUniqueName());
+    assertEquals("V_(14,15)", vertexV.getUniqueName());
 
     assertEquals("E", edgeE.getName());
-    assertEquals("(22,23)", edgeE.getUniqueName());
+    assertEquals("E_(22,23)", edgeE.getUniqueName());
   }
 
   @Test
@@ -151,16 +151,16 @@ public class UniqueNameGenerationTest extends AbstractPgqlTest {
     ExpAsVar expAsVar4 = selectQuery.getGroupBy().getElements().get(1);
 
     assertEquals("PROP", expAsVar1.getName());
-    assertEquals("(9,13)", expAsVar1.getUniqueName());
+    assertEquals("PROP_(9,13)", expAsVar1.getUniqueName());
 
     assertEquals("n.c*2", expAsVar2.getName());
-    assertEquals("(15,20)", expAsVar2.getUniqueName());
+    assertEquals("n.c*2_(15,20)", expAsVar2.getUniqueName());
 
     assertEquals("n.prop", expAsVar3.getName());
-    assertEquals("(45,51)", expAsVar3.getUniqueName());
+    assertEquals("n.prop_(45,51)", expAsVar3.getUniqueName());
 
     assertEquals("n.c*2", expAsVar4.getName());
-    assertEquals("(53,58)", expAsVar4.getUniqueName());
+    assertEquals("n.c*2_(53,58)", expAsVar4.getUniqueName());
   }
 
   @Test

--- a/pgql-lang/src/test/java/oracle/pgql/lang/UniqueNameGenerationTest.java
+++ b/pgql-lang/src/test/java/oracle/pgql/lang/UniqueNameGenerationTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2013 - 2024 Oracle and/or its affiliates. All rights reserved.
+ */
+package oracle.pgql.lang;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import oracle.pgql.lang.ir.ExpAsVar;
+import oracle.pgql.lang.ir.GraphPattern;
+import oracle.pgql.lang.ir.GraphQuery;
+import oracle.pgql.lang.ir.QueryEdge;
+import oracle.pgql.lang.ir.QueryExpression.Function.Exists;
+import oracle.pgql.lang.ir.QueryExpression.PropertyAccess;
+import oracle.pgql.lang.ir.QueryExpression.Subquery;
+import oracle.pgql.lang.ir.QueryExpression.VarRef;
+import oracle.pgql.lang.ir.QueryPath;
+import oracle.pgql.lang.ir.QueryVariable;
+import oracle.pgql.lang.ir.QueryVertex;
+import oracle.pgql.lang.ir.SelectQuery;
+import oracle.pgql.lang.ir.VertexPairConnection;
+import oracle.pgql.lang.ir.modify.EdgeInsertion;
+import oracle.pgql.lang.ir.modify.InsertClause;
+import oracle.pgql.lang.ir.modify.ModifyQuery;
+import oracle.pgql.lang.ir.modify.VertexInsertion;
+import oracle.pgql.lang.ir.unnest.OneRowPerEdge;
+import oracle.pgql.lang.ir.unnest.OneRowPerStep;
+import oracle.pgql.lang.ir.unnest.OneRowPerVertex;
+import oracle.pgql.lang.util.AbstractQueryExpressionVisitor;
+
+public class UniqueNameGenerationTest extends AbstractPgqlTest {
+
+  @Test
+  public void testUniqueVertexNameAndCorrelation() throws Exception {
+    PgqlResult result = pgql.parse("SELECT COUNT(*) FROM MATCH (n) WHERE EXISTS ( SELECT 1 FROM MATCH (n) -> (m) )");
+    assertTrue(result.isQueryValid());
+
+    GraphPattern graphPattern = result.getGraphQuery().getGraphPattern();
+    QueryVertex vertexN1 = graphPattern.getVertices().iterator().next();
+    assertEquals("N", vertexN1.getName());
+    assertEquals("(28,29)", vertexN1.getUniqueName());
+
+    Exists existsSubquery = (Exists) graphPattern.getConstraints().iterator().next();
+    Iterator<QueryVertex> it = existsSubquery.getQuery().getGraphPattern().getVertices().iterator();
+    QueryVertex vertexN2 = it.next();
+    QueryVertex vertexM = it.next();
+
+    assertEquals("N", vertexN2.getName());
+    assertEquals("(67,68)", vertexN2.getUniqueName());
+    assertEquals("(28,29)", vertexN2.getCorrelationVertexInOuterQuery().getUniqueName());
+
+    assertEquals("M", vertexM.getName());
+    assertEquals("(74,75)", vertexM.getUniqueName());
+    assertNull(vertexM.getCorrelationVertexInOuterQuery());
+  }
+
+  @Test
+  public void testUniqueEdgeNameAndCorrelation() throws Exception {
+    PgqlResult result = pgql.parse("SELECT COUNT(*) FROM MATCH () -[e1]-> () -[e2]-> ()");
+    assertTrue(result.isQueryValid());
+
+    GraphPattern graphPattern = result.getGraphQuery().getGraphPattern();
+    Iterator<VertexPairConnection> it = graphPattern.getConnections().iterator();
+    QueryEdge edgeE1 = (QueryEdge) it.next();
+    QueryEdge edgeE2 = (QueryEdge) it.next();
+
+    assertEquals("E1", edgeE1.getName());
+    assertEquals("(32,34)", edgeE1.getUniqueName());
+
+    assertEquals("E2", edgeE2.getName());
+    assertEquals("(43,45)", edgeE2.getUniqueName());
+  }
+
+  @Test
+  public void testUniqueNameInRowsClause() throws Exception {
+    PgqlResult result = pgql.parse("SELECT 1 FROM MATCH () ->{1,4} () ONE ROW PER VERTEX (v)");
+    assertTrue(result.isQueryValid());
+
+    GraphPattern graphPattern = result.getGraphQuery().getGraphPattern();
+    QueryPath path = (QueryPath) graphPattern.getConnections().iterator().next();
+    OneRowPerVertex oneRowPerVertex = (OneRowPerVertex) path.getRowsPerMatch();
+
+    assertEquals("V", oneRowPerVertex.getVertex().getName());
+    assertEquals("(54,55)", oneRowPerVertex.getVertex().getUniqueName());
+
+    result = pgql.parse("SELECT 1 FROM MATCH () ->{1,4} () ONE ROW PER EDGE (e)");
+    assertTrue(result.isQueryValid());
+
+    graphPattern = result.getGraphQuery().getGraphPattern();
+    path = (QueryPath) graphPattern.getConnections().iterator().next();
+    OneRowPerEdge oneRowPerEdge = (OneRowPerEdge) path.getRowsPerMatch();
+
+    assertEquals("E", oneRowPerEdge.getEdge().getName());
+    assertEquals("(52,53)", oneRowPerEdge.getEdge().getUniqueName());
+
+    result = pgql.parse("SELECT 1 FROM MATCH () ->{1,4} () ONE ROW PER STEP (v1, e, v2)");
+    assertTrue(result.isQueryValid());
+
+    graphPattern = result.getGraphQuery().getGraphPattern();
+    path = (QueryPath) graphPattern.getConnections().iterator().next();
+    OneRowPerStep oneRowPerStep = (OneRowPerStep) path.getRowsPerMatch();
+
+    assertEquals("V1", oneRowPerStep.getVertex1().getName());
+    assertEquals("(52,54)", oneRowPerStep.getVertex1().getUniqueName());
+    assertEquals("E", oneRowPerStep.getEdge().getName());
+    assertEquals("(56,57)", oneRowPerStep.getEdge().getUniqueName());
+    assertEquals("V2", oneRowPerStep.getVertex2().getName());
+    assertEquals("(59,61)", oneRowPerStep.getVertex2().getUniqueName());
+  }
+
+  @Test
+  public void testUniqueNameInInsert() throws Exception {
+    PgqlResult result = pgql.parse("INSERT VERTEX v, EDGE e BETWEEN v AND v");
+    assertTrue(result.isQueryValid());
+
+    ModifyQuery modifyQuery = (ModifyQuery) result.getGraphQuery();
+    InsertClause insertClause = (InsertClause) modifyQuery.getModifications().iterator().next();
+
+    VertexInsertion vertexInsertion = (VertexInsertion) insertClause.getInsertions().get(0);
+    EdgeInsertion edgeInsertion = (EdgeInsertion) insertClause.getInsertions().get(1);
+
+    QueryVertex vertexV = vertexInsertion.getVertex();
+    QueryEdge edgeE = edgeInsertion.getEdge();
+
+    assertEquals("V", vertexV.getName());
+    assertEquals("(14,15)", vertexV.getUniqueName());
+
+    assertEquals("E", edgeE.getName());
+    assertEquals("(22,23)", edgeE.getUniqueName());
+  }
+
+  @Test
+  public void testUniqueNameInExpAsVar() throws Exception {
+    PgqlResult result = pgql.parse("SELECT n.prop, n.c*2 FROM MATCH (n) GROUP BY n.prop, n.c*2");
+    assertTrue(result.isQueryValid());
+
+    SelectQuery selectQuery = (SelectQuery) result.getGraphQuery();
+    ExpAsVar expAsVar1 = selectQuery.getProjection().getElements().get(0);
+    ExpAsVar expAsVar2 = selectQuery.getProjection().getElements().get(1);
+    ExpAsVar expAsVar3 = selectQuery.getGroupBy().getElements().get(0);
+    ExpAsVar expAsVar4 = selectQuery.getGroupBy().getElements().get(1);
+
+    assertEquals("PROP", expAsVar1.getName());
+    assertEquals("(9,13)", expAsVar1.getUniqueName());
+
+    assertEquals("n.c*2", expAsVar2.getName());
+    assertEquals("(15,20)", expAsVar2.getUniqueName());
+
+    assertEquals("n.prop", expAsVar3.getName());
+    assertEquals("(45,51)", expAsVar3.getUniqueName());
+
+    assertEquals("n.c*2", expAsVar4.getName());
+    assertEquals("(53,58)", expAsVar4.getUniqueName());
+  }
+
+  @Test
+  public void testQueryCorrelation() throws Exception {
+    assertTrue(
+        isSubqueryInWhereCorrelated("SELECT 1 FROM MATCH (n) WHERE EXISTS ( SELECT * FROM MATCH (n) -[e]-> (m) )"));
+    assertFalse(
+        isSubqueryInWhereCorrelated("SELECT 1 FROM MATCH (n) WHERE EXISTS ( SELECT * FROM MATCH (n2) -[e]-> (m) )"));
+    assertTrue(isSubqueryInWhereCorrelated(
+        "SELECT 1 FROM MATCH (n) WHERE EXISTS ( SELECT * FROM MATCH (n2) -[e]-> (m) WHERE n.prop > 3 )"));
+    assertFalse(isSubqueryInWhereCorrelated(
+        "SELECT COUNT(*) FROM MATCH (a) WHERE EXISTS ( SELECT COUNT(*) FROM MATCH (b)->() GROUP by b ORDER BY COUNT(*) DESC LIMIT 1 )"));
+    assertTrue(isSubqueryInWhereCorrelated(
+        "SELECT 1 FROM MATCH () -[e]-> () WHERE EXISTS ( SELECT * FROM MATCH (n) WHERE n IS SOURCE OF e )"));
+    assertFalse(isSubqueryInWhereCorrelated(
+        "SELECT 1 FROM MATCH () WHERE EXISTS ( SELECT * FROM MATCH (n) -[e]-> () WHERE n IS SOURCE OF e )"));
+    assertTrue(isSubqueryInWhereCorrelated("SELECT id(n), n.timeProp FROM MATCH (n)" + //
+        "         WHERE (SELECT o.timeWithTimezoneProp FROM MATCH (o)" + //
+        "                WHERE d(o) = id(n) ) ORDER BY id(n)"));
+
+    PgqlResult result = pgql.parse("SELECT n.age " + //
+        "         MATCH (n) " + //
+        "         GROUP BY n.age " + //
+        "         HAVING EXISTS ( SELECT 1 " + //
+        "                         MATCH (m) -> (o) " + //
+        "                         GROUP BY n.age, m " + //
+        "                         HAVING COUNT(o) + n.age = 25 )");
+    Subquery subquery = (Subquery) result.getGraphQuery().getHaving();
+    assertTrue(isCorrelated(subquery.getQuery()));
+
+    result = pgql.parse(
+        "SELECT element_number(k), (SELECT element_number(k) FROM MATCH (n2) WHERE id(n2) = element_number(k)) \n"
+            + "         FROM MATCH ANY SHORTEST (n) ((src)-[e]->(dst)){2} (m) ONE ROW PER VERTEX (k) WHERE id(k) > 4");
+    subquery = (Subquery) ((SelectQuery) result.getGraphQuery()).getProjection().getElements().get(1).getExp();
+    assertTrue(isCorrelated(subquery.getQuery()));
+  }
+
+  private boolean isSubqueryInWhereCorrelated(String query) throws Exception {
+    PgqlResult result = pgql.parse(query);
+    assertTrue(result.isQueryValid());
+    GraphPattern graphPattern = result.getGraphQuery().getGraphPattern();
+    Subquery subquery = (Subquery) graphPattern.getConstraints().iterator().next();
+    return isCorrelated(subquery.getQuery());
+  }
+
+  private boolean isCorrelated(GraphQuery subquery) {
+
+    Set<QueryVariable> correlationVariables = new HashSet<>();
+    Set<String> definedVariables = new HashSet<>();
+    Map<String, QueryVariable> referencedVariables = new HashMap<>();
+
+    subquery.accept(new AbstractQueryExpressionVisitor() {
+
+      @Override
+      public void visit(QueryVertex queryVertex) {
+        definedVariables.add(queryVertex.getUniqueName());
+
+        QueryVariable correlationVariable = queryVertex.getCorrelationVertexInOuterQuery();
+        if (correlationVariable != null) {
+          correlationVariables.add(correlationVariable);
+        }
+      }
+
+      @Override
+      public void visit(QueryEdge queryEdge) {
+        definedVariables.add(queryEdge.getUniqueName());
+
+        QueryVariable correlationVariable = queryEdge.getCorrelationEdgeInOuterQuery();
+        if (correlationVariable != null) {
+          correlationVariables.add(correlationVariable);
+        }
+      }
+
+      @Override
+      public void visit(ExpAsVar expAsVar) {
+        definedVariables.add(expAsVar.getUniqueName());
+        super.visit(expAsVar);
+      }
+
+      @Override
+      public void visit(VarRef varRef) {
+        QueryVariable var = varRef.getVariable();
+        referencedVariables.put(var.getUniqueName(), var);
+      }
+
+      @Override
+      public void visit(PropertyAccess propertyAccess) {
+        QueryVariable var = propertyAccess.getVariable();
+        referencedVariables.put(var.getUniqueName(), var);
+      }
+    });
+
+    for (String definedVariable : definedVariables) {
+      referencedVariables.remove(definedVariable);
+    }
+
+    if (definedVariables.contains(null) || referencedVariables.containsKey(null)) {
+      throw new IllegalStateException("Unique name should not be null");
+    }
+
+    return !(correlationVariables.isEmpty() && referencedVariables.isEmpty());
+  }
+}


### PR DESCRIPTION
Two variables may have the same name. For example when they appear in different subqueries or different clauses.

This PR adds a getUniqueName() to each variable that allows for distinguishing the variables names from one another.

The unique name is based on the offset of the variable in the original query text (e.g. in case of `SELECT 123 AS var FROM ...`, variable `var` will have unique name `var_(14, 17)` since character `v` has (0-based) index 14 and the space after `r` has index 17.